### PR TITLE
Add a function to determine whether a race is at war

### DIFF
--- a/SupremacyCore/AI/InfluenceMapHelper.cs
+++ b/SupremacyCore/AI/InfluenceMapHelper.cs
@@ -40,7 +40,7 @@ namespace Supremacy.AI
 
             game.Civilizations
                 .AsParallel()
-                .Where(c => (owner != c) && DiplomacyHelper.AreEnemies(owner, c))
+                .Where(c => (owner != c) && DiplomacyHelper.AreAtWar(owner, c))
                 .SelectMany(c => game.Universe.FindOwned<Fleet>(c))
                 .Where(f => f.IsCombatant)
                 .SelectMany(f => GetFleetInfluence(game, f))

--- a/SupremacyCore/Diplomacy/DiplomacyHelper.cs
+++ b/SupremacyCore/Diplomacy/DiplomacyHelper.cs
@@ -289,6 +289,9 @@ namespace Supremacy.Diplomacy
                    diplomacyData.Status >=ForeignPowerStatus.Friendly;
         }
 
+        /// <summary>
+        ///  Determines whether two particular civilizations are at war
+        /// </summary>
         public static bool AreAtWar(Civilization who, Civilization whoElse)
         {
             if (who == null)
@@ -302,6 +305,14 @@ namespace Supremacy.Diplomacy
                    diplomacyData.Status == ForeignPowerStatus.AtWar;
         }
 
+        /// <summary>
+        /// Determines whether the given civilization is at war with anybody
+        /// </summary>
+        public static bool IsAtWar(Civilization who)
+        {
+            return (GameContext.Current.DiplomacyData.CountWhere(c => c.Status == ForeignPowerStatus.AtWar) > 0);
+        }
+
         public static bool AreNeutral(Civilization who, Civilization whoElse)
         {
             if (who == null)
@@ -313,11 +324,6 @@ namespace Supremacy.Diplomacy
 
             return diplomacyData != null &&
                    diplomacyData.Status == ForeignPowerStatus.Neutral;
-        }
-
-        public static bool AreEnemies(Civilization who, Civilization whoElse)
-        {
-            return AreAtWar(who, whoElse);
         }
 
         public static bool IsIndependent([NotNull] Civilization minorPower)


### PR DESCRIPTION
At the moment, it is only possible to determine whether two races are at war with each other, not whether a single race is at war with anybody. This function does that, and will be needed to improve the AI