### PR TITLE
Hopefully a fix for #26

### DIFF
--- a/SupremacyCore/Orbitals/Fleet.cs
+++ b/SupremacyCore/Orbitals/Fleet.cs
@@ -627,6 +627,11 @@ namespace Supremacy.Orbitals
                 civManager.MapData.SetScanned(Location, true, SensorRange);
             }
 
+            if (_order != null)
+            {
+                _order.OnFleetMoved();
+            }
+
             if (Interlocked.CompareExchange(ref _movementSempaphore, 0, 0) == 0)
                 return;
 
@@ -812,11 +817,7 @@ namespace Supremacy.Orbitals
             Interlocked.Increment(ref _movementSempaphore);
             try
             {
-                var lastLocation = Location;
                 Location = nextSector.Location;
-
-                if ((_order != null) && (Location != lastLocation))
-                    _order.OnFleetMoved();
             }
             finally
             {

--- a/SupremacyCore/Orbitals/FleetOrder.cs
+++ b/SupremacyCore/Orbitals/FleetOrder.cs
@@ -241,6 +241,17 @@ namespace Supremacy.Orbitals
         }
 
         /// <summary>
+        /// Gets a value indicating whether this <see cref="FleetOrder"/> is cancelled when the
+        /// location of this fleet is changed
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this <see cref="FleetOrder"/> is cancelled; otherwise, <c>false</c></value>.
+        public virtual bool IsCancelledOnMove
+        {
+            get { return false; }
+        }
+
+        /// <summary>
         /// Gets a value indicating whether a fleet will engage hostiles when assigned this <see cref="FleetOrder"/>.
         /// </summary>
         /// <value><c>true</c> if fleet will engage hostiles; otherwise, <c>false</c>.</value>
@@ -323,13 +334,24 @@ namespace Supremacy.Orbitals
         /// </summary>
         protected internal virtual void OnFleetRouteChanged()
         {
+            Fleet fleet = Fleet;
+            if ((fleet != null) && IsCancelledOnRouteChange)
+            {
+                fleet.SetOrder(fleet.GetDefaultOrder());
+            }
             OnPropertyChanged("DisplayText");
         }
 
         /// <summary>
         /// Called when a fleet moves while this <see cref="FleetOrder"/> is assigned.
         /// </summary>
-        protected internal virtual void OnFleetMoved() { }
+        public virtual void OnFleetMoved() {
+            Fleet fleet = Fleet;
+            if ((fleet != null) && IsCancelledOnMove)
+            {
+                fleet.SetOrder(fleet.GetDefaultOrder());
+            }
+        }
 
         /// <summary>
         /// Called when ships are added or removed from a fleet when this <see cref="FleetOrder"/> is assigned.

--- a/SupremacyCore/Orbitals/FleetOrders.cs
+++ b/SupremacyCore/Orbitals/FleetOrders.cs
@@ -1719,6 +1719,10 @@ namespace Supremacy.Orbitals
             get { return true; }
         }
 
+        public override bool IsCancelledOnMove {
+            get { return true; }
+        }
+
         public override bool IsComplete
         {
             get { return (BuildProject != null) && BuildProject.IsCompleted; }

--- a/SupremacyCore/Orbitals/FleetOrders.cs
+++ b/SupremacyCore/Orbitals/FleetOrders.cs
@@ -1215,7 +1215,7 @@ namespace Supremacy.Orbitals
                 Fleet.SetOrder(Fleet.GetDefaultOrder());
         }
 
-        protected internal override void OnFleetMoved()
+        public override void OnFleetMoved()
         {
             base.OnFleetMoved();
             if (TargetFleet != null)
@@ -1868,6 +1868,13 @@ namespace Supremacy.Orbitals
             var destroyedShip = Fleet.Ships.FirstOrDefault(o => o.ShipType == ShipType.Construction);
             if (destroyedShip != null)
                 GameContext.Current.Universe.Destroy(destroyedShip);
+        }
+
+        public override void OnFleetMoved()
+        {
+            base.OnFleetMoved();
+            if (BuildProject != null)
+                BuildProject.Cancel();
         }
 
         #region FleetProductionCenter Class


### PR DESCRIPTION
Before, the OnFleetMoved method was only called when a fleet was moved along a route, not when the fleet was moved by an event such as retreat or going through a wormhole. This fixes that.

It also adds IsCancelledOnMove to a fleet order

Hopefully, through both of these, the station build order is cancelled when the ship is forced to move out of a system, instead of it crashing.

I have been unable to test it unfortunately