### PR TITLE
Attempt to start using a master copy of civ database (#46)

### DIFF
--- a/SupremacyClient/MultiplayerLobby.xaml.cs
+++ b/SupremacyClient/MultiplayerLobby.xaml.cs
@@ -81,7 +81,7 @@ namespace Supremacy.Client
             if (AppContext.IsSinglePlayerGame)
                 return;
 
-                UpdateSlots(lobbyData);
+            UpdateSlots(lobbyData);
         }
 
         private void OnClientDisconnected(EventArgs args)
@@ -130,55 +130,64 @@ namespace Supremacy.Client
             GameLog.Print("EmpireID-Selected={0} ", AppContext.LocalPlayer.EmpireID);
 
             // IMPORTANT: at the moment only LocalPlayer is checked whether it's set to NOT Playable. At the moment NO check for the other players in Multi Player
-            int IntroRaceIsIn = 1; //  1 = Out of game, 0 = In game
-            // Todo: find a way to compare String = "INTRO" (if Intro is removed, Fed is 0)
-
-            if (OptionsPanel.Options.IntroPlayable == EmpirePlayable.No && AppContext.LocalPlayer.EmpireID + IntroRaceIsIn == 0)
+            switch (MasterResources.CivDB[AppContext.LocalPlayer.EmpireID].ShortName)
             {
-                MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_0_NOT_IN GAME"), MessageDialogButtons.Ok);
-                return;
-            }
-
-            if (OptionsPanel.Options.FederationPlayable == EmpirePlayable.No && AppContext.LocalPlayer.EmpireID + IntroRaceIsIn == 1)
-            {
-                MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_1_NOT_IN GAME"), MessageDialogButtons.Ok);
-                return;
-            }
-
-            if (OptionsPanel.Options.TerranEmpirePlayable == EmpirePlayable.No && AppContext.LocalPlayer.EmpireID + IntroRaceIsIn == 2)
-            {
-                MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_2_NOT_IN GAME"), MessageDialogButtons.Ok);
-                return;
-            }
-
-            if (OptionsPanel.Options.RomulanPlayable == EmpirePlayable.No && AppContext.LocalPlayer.EmpireID + IntroRaceIsIn == 3)
-            {
-                MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_3_NOT_IN GAME"), MessageDialogButtons.Ok);
-                return;
-            }
-
-            if (OptionsPanel.Options.KlingonPlayable == EmpirePlayable.No && AppContext.LocalPlayer.EmpireID + IntroRaceIsIn == 4)
-            {
-                MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_4_NOT_IN GAME"), MessageDialogButtons.Ok);
-                return;
-            }
-
-            if (OptionsPanel.Options.CardassianPlayable == EmpirePlayable.No && AppContext.LocalPlayer.EmpireID + IntroRaceIsIn == 5)
-            {
-                MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_5_NOT_IN GAME"), MessageDialogButtons.Ok);
-                return;
-            }
-
-            if (OptionsPanel.Options.DominionPlayable == EmpirePlayable.No && AppContext.LocalPlayer.EmpireID + IntroRaceIsIn == 6)
-            {
-                MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_6_NOT_IN GAME"), MessageDialogButtons.Ok);
-                return;
-            }
-
-            if (OptionsPanel.Options.BorgPlayable == EmpirePlayable.No && AppContext.LocalPlayer.EmpireID + IntroRaceIsIn == 7)
-            {
-                MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_7_NOT_IN GAME"), MessageDialogButtons.Ok);
-                return;
+                case "Intro":
+                    if (OptionsPanel.Options.IntroPlayable == EmpirePlayable.No)
+                    {
+                        MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_0_NOT_IN GAME"), MessageDialogButtons.Ok);
+                        return;
+                    }
+                    break;
+                case "Federation":
+                    if (OptionsPanel.Options.FederationPlayable == EmpirePlayable.No)
+                    {
+                        MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_1_NOT_IN GAME"), MessageDialogButtons.Ok);
+                        return;
+                    }
+                    break;
+                case "Terran Empire":
+                    if (OptionsPanel.Options.TerranEmpirePlayable == EmpirePlayable.No)
+                    {
+                        MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_2_NOT_IN GAME"), MessageDialogButtons.Ok);
+                        return;
+                    }
+                    break;
+                case "Romulans":
+                    if (OptionsPanel.Options.RomulanPlayable == EmpirePlayable.No)
+                    {
+                        MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_3_NOT_IN GAME"), MessageDialogButtons.Ok);
+                        return;
+                    }
+                    break;
+                case "Klingons":
+                    if (OptionsPanel.Options.KlingonPlayable == EmpirePlayable.No)
+                    {
+                        MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_4_NOT_IN GAME"), MessageDialogButtons.Ok);
+                        return;
+                    }
+                    break;
+                case "Cardassians":
+                    if (OptionsPanel.Options.CardassianPlayable == EmpirePlayable.No)
+                    {
+                        MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_5_NOT_IN GAME"), MessageDialogButtons.Ok);
+                        return;
+                    }
+                    break;
+                case "Dominion":
+                    if (OptionsPanel.Options.DominionPlayable == EmpirePlayable.No)
+                    {
+                        MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_6_NOT_IN GAME"), MessageDialogButtons.Ok);
+                        return;
+                    }
+                    break;
+                case "Borg":
+                    if (OptionsPanel.Options.BorgPlayable == EmpirePlayable.No)
+                    {
+                        MessageDialog.Show(Environment.NewLine + _resourceManager.GetString("CIV_7_NOT_IN GAME"), MessageDialogButtons.Ok);
+                        return;
+                    }
+                    break;
             }
 
             GameLog.Print("EmpireID STARTING Game={0}", AppContext.LocalPlayer.EmpireID);

--- a/SupremacyClient/SinglePlayerStartScreen.xaml.cs
+++ b/SupremacyClient/SinglePlayerStartScreen.xaml.cs
@@ -12,6 +12,7 @@ using Supremacy.Client.Audio;
 using Supremacy.Client.Dialogs;
 using Supremacy.Entities;
 using Supremacy.Game;
+using Supremacy.Resources;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -51,7 +52,7 @@ namespace Supremacy.Client
                 CivSelector.SelectionChanged += CivSelector_SelectionChanged;
 
                 //Select Federation to begin with
-                List<Civilization> tmp = (List<Civilization>)DataContext;                
+                List<Civilization> tmp = (List<Civilization>)DataContext;
                 if (tmp[0].ShortName == "Intro")
                 {
                     CivSelector.SelectedIndex = 1;
@@ -134,7 +135,7 @@ namespace Supremacy.Client
                         if (Options.IntroPlayable == EmpirePlayable.No)
                         {
                             MessageDialog.Show(Environment.NewLine +
-                                Supremacy.Resources.ResourceManager.GetString("CIV_0_NOT_IN GAME"), MessageDialogButtons.Ok);
+                                ResourceManager.GetString("CIV_0_NOT_IN GAME"), MessageDialogButtons.Ok);
                             return;
                         }
                         break;
@@ -142,7 +143,7 @@ namespace Supremacy.Client
                         if (Options.FederationPlayable == EmpirePlayable.No)
                         {
                             MessageDialog.Show(Environment.NewLine +
-                                Supremacy.Resources.ResourceManager.GetString("CIV_1_NOT_IN GAME"), MessageDialogButtons.Ok);
+                                ResourceManager.GetString("CIV_1_NOT_IN GAME"), MessageDialogButtons.Ok);
                             return;
                         }
                         break;
@@ -150,7 +151,7 @@ namespace Supremacy.Client
                         if (Options.TerranEmpirePlayable == EmpirePlayable.No)
                         {
                             MessageDialog.Show(Environment.NewLine +
-                                Supremacy.Resources.ResourceManager.GetString("CIV_2_NOT_IN GAME"), MessageDialogButtons.Ok);
+                                ResourceManager.GetString("CIV_2_NOT_IN GAME"), MessageDialogButtons.Ok);
                             return;
                         }
                         break;
@@ -158,7 +159,7 @@ namespace Supremacy.Client
                         if (Options.RomulanPlayable == EmpirePlayable.No)
                         {
                             MessageDialog.Show(Environment.NewLine +
-                                Supremacy.Resources.ResourceManager.GetString("CIV_3_NOT_IN GAME"), MessageDialogButtons.Ok);
+                                ResourceManager.GetString("CIV_3_NOT_IN GAME"), MessageDialogButtons.Ok);
                             return;
                         }
                         break;
@@ -166,7 +167,7 @@ namespace Supremacy.Client
                         if (Options.KlingonPlayable == EmpirePlayable.No)
                         {
                             MessageDialog.Show(Environment.NewLine +
-                                Supremacy.Resources.ResourceManager.GetString("CIV_4_NOT_IN GAME"), MessageDialogButtons.Ok);
+                                ResourceManager.GetString("CIV_4_NOT_IN GAME"), MessageDialogButtons.Ok);
                             return;
                         }
                         break;
@@ -174,7 +175,7 @@ namespace Supremacy.Client
                         if (Options.CardassianPlayable == EmpirePlayable.No)
                         {
                             MessageDialog.Show(Environment.NewLine +
-                                Supremacy.Resources.ResourceManager.GetString("CIV_5_NOT_IN GAME"), MessageDialogButtons.Ok);
+                                ResourceManager.GetString("CIV_5_NOT_IN GAME"), MessageDialogButtons.Ok);
                             return;
                         }
                         break;
@@ -182,7 +183,7 @@ namespace Supremacy.Client
                         if (Options.DominionPlayable == EmpirePlayable.No)
                         {
                             MessageDialog.Show(Environment.NewLine +
-                                Supremacy.Resources.ResourceManager.GetString("CIV_6_NOT_IN GAME"), MessageDialogButtons.Ok);
+                                ResourceManager.GetString("CIV_6_NOT_IN GAME"), MessageDialogButtons.Ok);
                             return;
                         }
                         break;
@@ -190,7 +191,7 @@ namespace Supremacy.Client
                         if (Options.BorgPlayable == EmpirePlayable.No)
                         {
                             MessageDialog.Show(Environment.NewLine +
-                                Supremacy.Resources.ResourceManager.GetString("CIV_7_NOT_IN GAME"), MessageDialogButtons.Ok);
+                                ResourceManager.GetString("CIV_7_NOT_IN GAME"), MessageDialogButtons.Ok);
                             return;
                         }
                         break;

--- a/SupremacyCore/Entities/CivDatabase.cs
+++ b/SupremacyCore/Entities/CivDatabase.cs
@@ -7,16 +7,16 @@
 //
 // All other rights reserved.
 
+using Supremacy.Collections;
+using Supremacy.Game;
+using Supremacy.Resources;
+using Supremacy.Types;
+using Supremacy.Utility;
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Xml.Linq;
 using System.Xml.Schema;
-
-using Supremacy.Collections;
-using Supremacy.Resources;
-using Supremacy.Types;
-using Supremacy.Game;
 
 namespace Supremacy.Entities
 {
@@ -252,6 +252,7 @@ namespace Supremacy.Entities
         /// <returns></returns>
         public static CivDatabase Load()
         {
+            GameLog.Print("Loading civilization database....");
             try
             {
                 var civDatabase = new CivDatabase();
@@ -267,6 +268,7 @@ namespace Supremacy.Entities
                 {
                     civDatabase.Add(new Civilization(civElement));
                 }
+                GameLog.Print("Civilization database loaded");
                 return civDatabase;
             }
             catch (SupremacyException)

--- a/SupremacyCore/Game/GameContext.cs
+++ b/SupremacyCore/Game/GameContext.cs
@@ -7,14 +7,10 @@
 //
 // All other rights reserved.
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Threading;
-using System.Windows;
-
+using Supremacy.AI;
 using Supremacy.Annotations;
 using Supremacy.Buildings;
+using Supremacy.Collections;
 using Supremacy.Diplomacy;
 using Supremacy.Economy;
 using Supremacy.Entities;
@@ -26,12 +22,13 @@ using Supremacy.Scripting;
 using Supremacy.Tech;
 using Supremacy.Text;
 using Supremacy.Universe;
-using Supremacy.Collections;
-using Supremacy.AI;
-
-using System.Linq;
-
 using Supremacy.Utility;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading;
+using System.Windows;
 //using Supremacy.Intel;
 
 namespace Supremacy.Game
@@ -859,9 +856,9 @@ namespace Supremacy.Game
             {
                 _gameMod = GameModLoader.GetModFromCommandLine();
                 _races = RaceDatabase.Load();
-                        GameLog.Client.GameData.DebugFormat("Races loaded");
+                    GameLog.Client.GameData.DebugFormat("Races loaded");
                 _civilizations = CivDatabase.Load();
-                        GameLog.Client.GameData.DebugFormat("Civilizations loaded");
+                    GameLog.Client.GameData.DebugFormat("Civilizations loaded");
                 _civManagers = new CivilizationManagerMap();
                 _tables = GameTables.Load();
                         GameLog.Client.GameData.DebugFormat("Tables loaded");
@@ -1209,48 +1206,6 @@ namespace Supremacy.Game
 
                 FixupDiplomacyData();
 
-                // TODO: Remove before release
-                /*var federation = _civilizations["FEDERATION"];
-                var fedManager = CivilizationManagers[federation];
-
-                var turn = GameContext.Current.TurnNumber;
-                GameContext.Current.TurnNumber = 1;
-                fedManager.AgentPool.Update();
-
-                var futureAgents = fedManager.AgentPool.FutureAgents;
-
-                while (futureAgents.Count != 0)
-                {
-                    fedManager.AgentPool.CurrentAgents.Add(new Agent(futureAgents[0].Profile, federation));
-                    futureAgents.RemoveAt(0);
-                }*/
-
-/*
-                _diplomacyData.GetValuesForOwner(federation).ForEach(
-                    o =>
-                    {
-                        var counterparty = Civilizations[o.CounterpartyID];
-
-                        DiplomacyHelper.EnsureContact(
-                            federation,
-                            counterparty,
-                            CivilizationManagers[o.CounterpartyID].HomeColony.Location,
-                            1);
-
-                        if (!counterparty.IsEmpire)
-                            return;
-                        
-                        var agent = fedManager.AgentPool.CurrentAgents.FirstOrDefault(a => !a.HasMission);
-                        if (agent == null)
-                            return;
-
-                        var envoyMission = new DiplomaticEnvoyMission(federation, counterparty, fedManager.HomeColony.Location);
-
-                        envoyMission.Assign(agent);
-                        envoyMission.Begin();
-                    });
-*/
-                //GameContext.Current.TurnNumber = turn;
             }
             finally
             {

--- a/SupremacyCore/Game/GameInitData.cs
+++ b/SupremacyCore/Game/GameInitData.cs
@@ -9,6 +9,7 @@
 
 using Supremacy.Annotations;
 using Supremacy.Entities;
+using Supremacy.Resources;
 using Supremacy.Utility;
 using System;
 using System.ComponentModel;
@@ -257,11 +258,10 @@ namespace Supremacy.Game
 
             try
             {
-                var civDatabase = CivDatabase.Load();
-                var empires = civDatabase.Where(o => o.IsEmpire).Select(o => new { o.Name, o.CivID });
+                var empires = CivDatabase.Load().Where(o => o.IsEmpire).Select(o => new { o.Name, o.CivID });
 
                 EmpireIDs = empires.Select(o => (int)o.CivID).ToArray();
-                    EmpireNames = empires.Select(o => o.Name).ToArray();
+                EmpireNames = empires.Select(o => o.Name).ToArray();
             }
             finally
             {

--- a/SupremacyCore/Resources/MasterResources.cs
+++ b/SupremacyCore/Resources/MasterResources.cs
@@ -1,0 +1,25 @@
+﻿using Supremacy.Entities;
+using Supremacy.Utility;
+
+namespace Supremacy.Resources
+{
+    public class MasterResources
+    {
+        private static CivDatabase m_CivDatabase;
+
+        public static CivDatabase CivDB
+        {
+            get
+            {
+                if (m_CivDatabase == null)
+                {
+                    GameLog.Print("Loading master copy of civilization database...");
+                    m_CivDatabase = CivDatabase.Load();
+                    GameLog.Print("Master civilization database loaded");
+                }
+                return m_CivDatabase;
+            }
+            private set { }
+        }
+    }
+}

--- a/SupremacyCore/SupremacyCore.csproj
+++ b/SupremacyCore/SupremacyCore.csproj
@@ -210,6 +210,7 @@
     <Compile Include="Personnel\MissionPhase.cs" />
     <Compile Include="Personnel\MissionPhaseChangedEventArgs.cs" />
     <Compile Include="Personnel\TrainingAssignment.cs" />
+    <Compile Include="Resources\MasterResources.cs" />
     <Compile Include="Scripting\CivilizationScopedEvent.cs" />
     <Compile Include="Scripting\EventDefinition.cs" />
     <Compile Include="Scripting\Events\AsteroidImpactEvent.cs" />

--- a/SupremacyUI/GalaxyGridPanel.cs
+++ b/SupremacyUI/GalaxyGridPanel.cs
@@ -7,6 +7,26 @@
 //
 // All other rights reserved.
 
+using Microsoft.Practices.Composite.Presentation.Events;
+using Microsoft.Practices.ServiceLocation;
+using Supremacy.Annotations;
+using Supremacy.Client;
+using Supremacy.Client.Audio;
+using Supremacy.Client.Commands;
+using Supremacy.Client.Context;
+using Supremacy.Client.Dialogs;
+using Supremacy.Client.Events;
+using Supremacy.Client.Input;
+using Supremacy.Client.Views;
+using Supremacy.Diplomacy;
+using Supremacy.Entities;
+using Supremacy.Game;
+using Supremacy.Orbitals;
+using Supremacy.Pathfinding;
+using Supremacy.Resources;
+using Supremacy.Types;
+using Supremacy.Universe;
+using Supremacy.Utility;
 using System;
 using System.Collections.Generic;
 using System.Concurrency;
@@ -22,28 +42,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
-
-using Microsoft.Practices.Composite.Presentation.Events;
-using Microsoft.Practices.ServiceLocation;
-
-using Supremacy.Annotations;
-using Supremacy.Client;
-using Supremacy.Client.Commands;
-using Supremacy.Client.Dialogs;
-using Supremacy.Client.Events;
-using Supremacy.Client.Input;
-using Supremacy.Client.Views;
-using Supremacy.Diplomacy;
-using Supremacy.Entities;
-using Supremacy.Game;
-using Supremacy.Orbitals;
-using Supremacy.Pathfinding;
-using Supremacy.Resources;
-using Supremacy.Types;
-using Supremacy.Universe;
-using Supremacy.Utility;
-using Supremacy.Client.Context;
-using Supremacy.Client.Audio;
 
 namespace Supremacy.UI
 {
@@ -231,8 +229,7 @@ namespace Supremacy.UI
             //Instead of loading the civilizations from the gamecontext,
             //load them straight from the db, as this panel is only constructed once.
             //Failure to do so will cause crashes when starting a second game
-            CivDatabase newCivDB = CivDatabase.Load();
-            foreach (var civ in newCivDB)
+            foreach (var civ in MasterResources.CivDB)
             {
                 var color = (Color) ColorConverter.ConvertFromString(civ.Color);
                 var textColor = Color.Add(color, Colors.Gray);


### PR DESCRIPTION
This starts to use a master copy of civ database. It means that the IntroIsIn variable is no longer needed whatsoever.

At the moment, attempting to use the master copy elsewhere results in any game options such as civs being expanding still being empires, so got to work that one out