### PR TITLE
Fix colony unmanagable after population reducing events

### DIFF
--- a/SupremacyCore/Scripting/Events/AsteroidImpactEvent.cs
+++ b/SupremacyCore/Scripting/Events/AsteroidImpactEvent.cs
@@ -1,28 +1,22 @@
-﻿//AsteroidImpactEvent.cs
-//
-// Copyright (c) 2009 Mike Strobel
+﻿// Copyright (c) 2009 Mike Strobel
 //
 // This source code is subject to the terms of the Microsoft Reciprocal License (Ms-RL).
 // For details, see <http://www.opensource.org/licenses/ms-rl.html>.
 //
 // All other rights reserved.
 
-using System;
-using System.Collections.Generic;
-
+using Supremacy.Buildings;
 using Supremacy.Economy;
 using Supremacy.Game;
-
-using System.Linq;
-
 using Supremacy.Universe;
 using Supremacy.Utility;
-using Supremacy.Buildings;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Supremacy.Scripting.Events
 {
     [Serializable]
-    //First class here deals with turning off production for one turn and reduction of population, see around line 157 158 about structures, buildings... 
     public class AsteroidImpactEvent : UnitScopedEvent<Colony> 
     {
         private bool _productionFinished;
@@ -31,7 +25,6 @@ namespace Supremacy.Scripting.Events
 
         [NonSerialized]
         private List<BuildProject> _affectedProjects;
-        //private List<BuildProject> _asteroidImpactUnits;
         protected List<BuildProject> AffectedProjects
         {
             get
@@ -41,8 +34,8 @@ namespace Supremacy.Scripting.Events
                 return _affectedProjects;
             }
         }
+
         private List<Building> _affectedBuildings;
-        //private List<BuildProject> _asteroidImpactUnits;
         protected List<Building> AffectedBuildings
         {
             get
@@ -53,12 +46,10 @@ namespace Supremacy.Scripting.Events
             }
         }
 
-
         public AsteroidImpactEvent()
         {
             _affectedProjects = new List<BuildProject>();
             _affectedBuildings = new List<Building>();
-            //_asteroidImpactUnits = new List<AsteroidImpactUnit>();
         }
 
         public override bool CanExecute
@@ -124,35 +115,23 @@ namespace Supremacy.Scripting.Events
                     foreach (var affectedProject in affectedProjects)
                     {
                         GameLog.Client.GameData.DebugFormat("AsteroidImpactEvents.cs: affectedProject: {0}", affectedProject.Description);
-
-
                         AffectedProjects.Add(affectedProject);
                     }
 
                     var targetCiv = target.Owner;
                     int targetColonyId = target.ObjectID;
                     var population = target.Population.CurrentValue;
-                    
-
-//Buildings
-        // BUNKER_NETWORK (deep in ground)
-        // DILITHIUM_REFINERY (basic structure)
-        // SUBSPACE_SCANNER (?)
 
                     List<Building> tmpBuildings = new List<Building>(target.Buildings.Count);
                     tmpBuildings.AddRange(target.Buildings.ToList());
                     tmpBuildings.ForEach(o => target.RemoveBuilding(o));
                     tmpBuildings.ForEach(o => o.ObjectID = GameObjectID.InvalidID);
-                    
-                    //GameLog.Client.GameData.DebugFormat("AsteroidImpactEvents.cs: affectedBuildings: {0}", target);
 
                     OnUnitTargeted(target);
 
-// Population
                     GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.AdjustCurrent(-population + 40);
                     GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.UpdateAndReset();
 
-// Facilities
                     int removeFood = target.GetTotalFacilities(ProductionCategory.Food) - 3; // Food: remaining everything up to 3
                     if (removeFood < 4)
                         removeFood = 0;
@@ -178,15 +157,10 @@ namespace Supremacy.Scripting.Events
                         removeIntelligence = 0;
                     target.RemoveFacilities(ProductionCategory.Intelligence, removeIntelligence); // Intelligence: remaining everything up to 0
 
-
-
-// OrbitalBatteries
                     int removeOrbitalBatteries = target.OrbitalBatteries.Count;  // OrbitalBatteries: remaining everything up to 1
                     if (removeOrbitalBatteries < 2)
                         removeOrbitalBatteries = 0;
                     target.RemoveOrbitalBatteries(removeOrbitalBatteries);
-
-                    //OnUnitTargeted(target);
 
                     game.CivilizationManagers[targetCiv].SitRepEntries.Add(
                         new ScriptedEventSitRepEntry(
@@ -199,10 +173,7 @@ namespace Supremacy.Scripting.Events
                                 "vfs:///Resources/SoundFX/ScriptedEvents/AsteroidImpact.wav",
                                 () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
 
-
-
                     GameContext.Current.Universe.UpdateSectors();
-
 
                     return;
                 }
@@ -221,7 +192,6 @@ namespace Supremacy.Scripting.Events
                 AffectedProjects.Clear();
             }
         }
-
     }
 }
 

--- a/SupremacyCore/Scripting/Events/CometStrike.cs
+++ b/SupremacyCore/Scripting/Events/CometStrike.cs
@@ -1,27 +1,22 @@
-﻿
-// Copyright (c) 2009 Mike Strobel
+﻿// Copyright (c) 2009 Mike Strobel
 //
 // This source code is subject to the terms of the Microsoft Reciprocal License (Ms-RL).
 // For details, see <http://www.opensource.org/licenses/ms-rl.html>.
 //
 // All other rights reserved.
 
-using System;
-using System.Collections.Generic;
-
+using Supremacy.Buildings;
 using Supremacy.Economy;
 using Supremacy.Game;
-
-using System.Linq;
-
 using Supremacy.Universe;
 using Supremacy.Utility;
-using Supremacy.Buildings;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Supremacy.Scripting.Events
 {
     [Serializable]
-    //First class here deals with turning off production for one turn and reduction of population, see around line 157 158 about structures, buildings... 
     public class CometStrikeEvent : UnitScopedEvent<Colony>
     {
         private bool _productionFinished;
@@ -30,7 +25,6 @@ namespace Supremacy.Scripting.Events
 
         [NonSerialized]
         private List<BuildProject> _affectedProjects;
-        //private List<BuildProject> _asteroidImpactUnits;
         protected List<BuildProject> AffectedProjects
         {
             get
@@ -40,8 +34,8 @@ namespace Supremacy.Scripting.Events
                 return _affectedProjects;
             }
         }
+
         private List<Building> _affectedBuildings;
-        //private List<BuildProject> _asteroidImpactUnits;
         protected List<Building> AffectedBuildings
         {
             get
@@ -52,12 +46,10 @@ namespace Supremacy.Scripting.Events
             }
         }
 
-
         public CometStrikeEvent()
         {
             _affectedProjects = new List<BuildProject>();
             _affectedBuildings = new List<Building>();
-            //_asteroidImpactUnits = new List<AsteroidImpactUnit>();
         }
 
         public override bool CanExecute
@@ -135,19 +127,6 @@ namespace Supremacy.Scripting.Events
                     int targetColonyId = target.ObjectID;
                     var population = target.Population.CurrentValue;
 
-
-                    //Buildings
-                    // BUNKER_NETWORK (deep in ground)
-                    // DILITHIUM_REFINERY (basic structure)
-                    // SUBSPACE_SCANNER (?)
-
-                    //List<Building> tmpBuildings = new List<Building>(target.Buildings.Count);
-                    //tmpBuildings.AddRange(target.Buildings.ToList());
-                    //tmpBuildings.ForEach(o => target.RemoveBuilding(o));
-                    //tmpBuildings.ForEach(o => o.ObjectID = GameObjectID.InvalidID);
-
-                    //GameLog.Client.GameData.DebugFormat("CometStrikeEvents.cs: affectedBuildings: {0}", target);
-
                     OnUnitTargeted(target);
 
                     // Population
@@ -180,14 +159,6 @@ namespace Supremacy.Scripting.Events
                         removeIntelligence = 0;
                     target.RemoveFacilities(ProductionCategory.Intelligence, removeIntelligence); // Intelligence: remaining everything up to 0
 
-                    //// OrbitalBatteries
-                    //int removeOrbitalBatteries = target.OrbitalBatteries.Count;  // OrbitalBatteries: remaining everything up to 1
-                    //if (removeOrbitalBatteries < 2)
-                    //    removeOrbitalBatteries = 0;
-                    //target.RemoveOrbitalBatteries(removeOrbitalBatteries);
-
-                    //OnUnitTargeted(target);
-
                     game.CivilizationManagers[targetCiv].SitRepEntries.Add(
                         new ScriptedEventSitRepEntry(
                             new ScriptedEventSitRepEntryData(
@@ -199,10 +170,7 @@ namespace Supremacy.Scripting.Events
                                 "vfs:///Resources/SoundFX/ScriptedEvents/AsteroidImpact.wav",
                                 () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
 
-
-
                     GameContext.Current.Universe.UpdateSectors();
-
 
                     return;
                 }
@@ -221,6 +189,5 @@ namespace Supremacy.Scripting.Events
                 AffectedProjects.Clear();
             }
         }
-
     }
 }

--- a/SupremacyCore/Scripting/Events/Earthquake.cs
+++ b/SupremacyCore/Scripting/Events/Earthquake.cs
@@ -129,7 +129,11 @@ namespace Supremacy.Scripting.Events
                     GameContext.Current.Universe.Get<Colony>(targetColonyId).Morale.AdjustCurrent(-5);
 
                     // Population
-                    GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.AdjustCurrent(-20);
+                    //Don't reduce the population beneath 20
+                    if (population >= 40)
+                    {
+                        GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.AdjustCurrent(-20);
+                    }
                     GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.UpdateAndReset();
 
                     // Facilities

--- a/SupremacyCore/Scripting/Events/Earthquake.cs
+++ b/SupremacyCore/Scripting/Events/Earthquake.cs
@@ -1,27 +1,22 @@
-﻿
-// Copyright (c) 2009 Mike Strobel
+﻿// Copyright (c) 2009 Mike Strobel
 //
 // This source code is subject to the terms of the Microsoft Reciprocal License (Ms-RL).
 // For details, see <http://www.opensource.org/licenses/ms-rl.html>.
 //
 // All other rights reserved.
 
-using System;
-using System.Collections.Generic;
-
+using Supremacy.Buildings;
 using Supremacy.Economy;
 using Supremacy.Game;
-
-using System.Linq;
-
 using Supremacy.Universe;
 using Supremacy.Utility;
-using Supremacy.Buildings;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Supremacy.Scripting.Events
 {
     [Serializable]
-    //First class here deals with turning off production for one turn and reduction of population, see around line 157 158 about structures, buildings... 
     public class EarthquakeEvent : UnitScopedEvent<Colony>
     {
         private bool _productionFinished;
@@ -30,7 +25,6 @@ namespace Supremacy.Scripting.Events
 
         [NonSerialized]
         private List<BuildProject> _affectedProjects;
-        //private List<BuildProject> _asteroidImpactUnits;
         protected List<BuildProject> AffectedProjects
         {
             get
@@ -40,8 +34,8 @@ namespace Supremacy.Scripting.Events
                 return _affectedProjects;
             }
         }
+
         private List<Building> _affectedBuildings;
-        //private List<BuildProject> _asteroidImpactUnits;
         protected List<Building> AffectedBuildings
         {
             get
@@ -52,12 +46,10 @@ namespace Supremacy.Scripting.Events
             }
         }
 
-
         public EarthquakeEvent()
         {
             _affectedProjects = new List<BuildProject>();
             _affectedBuildings = new List<Building>();
-            //_asteroidImpactUnits = new List<AsteroidImpactUnit>();
         }
 
         public override bool CanExecute
@@ -115,9 +107,6 @@ namespace Supremacy.Scripting.Events
                     var target = productionCenters[RandomProvider.Next(productionCenters.Count)];
                     GameLog.Client.GameData.DebugFormat("EarthquakeEvents.cs: target.Name: {0}", target.Name);
 
-                    //if (target.Name == "Sol" || target.Name == "Terra" || target.Name == "Cardassia" || target.Name == "Qo'nos" || target.Name == "Omarion Nebula" || target.Name == "Romulus" || target.Name == "Borg Nebula")
-                    //    return;
-
                     var affectedProjects = target.BuildSlots
                     .Concat((target.Shipyard != null) ? target.Shipyard.BuildSlots : Enumerable.Empty<BuildSlot>())
                     .Where(o => o.HasProject && !o.Project.IsPaused && !o.Project.IsCancelled)
@@ -134,19 +123,6 @@ namespace Supremacy.Scripting.Events
                     var targetCiv = target.Owner;
                     int targetColonyId = target.ObjectID;
                     var population = target.Population.CurrentValue;
-
-
-                    //Buildings
-                    // BUNKER_NETWORK (deep in ground)
-                    // DILITHIUM_REFINERY (basic structure)
-                    // SUBSPACE_SCANNER (?)
-
-                    //List<Building> tmpBuildings = new List<Building>(target.Buildings.Count);
-                    //tmpBuildings.AddRange(target.Buildings.ToList());
-                    //tmpBuildings.ForEach(o => target.RemoveBuilding(o));
-                    //tmpBuildings.ForEach(o => o.ObjectID = GameObjectID.InvalidID);
-
-                    //GameLog.Client.GameData.DebugFormat("EarthquakeEvents.cs: affectedBuildings: {0}", target);
 
                     OnUnitTargeted(target);
 
@@ -172,24 +148,6 @@ namespace Supremacy.Scripting.Events
                         removeEnergy = 0;
                     target.RemoveFacilities(ProductionCategory.Energy, removeEnergy);
 
-                    //int removeResearch = target.GetTotalFacilities(ProductionCategory.Research - 1);  // Research: remaining everything up to 1
-                    //if (removeResearch < 2)
-                    //    removeResearch = 0;
-                    //target.RemoveFacilities(ProductionCategory.Research, removeResearch);
-
-                    //int removeIntelligence = target.GetTotalFacilities(ProductionCategory.Intelligence - 3);  // Research: remaining everything up to 3
-                    //if (removeIntelligence < 4)
-                    //    removeIntelligence = 0;
-                    //target.RemoveFacilities(ProductionCategory.Intelligence, removeIntelligence); // Intelligence: remaining everything up to 0
-
-                    //// OrbitalBatteries
-                    //int removeOrbitalBatteries = target.OrbitalBatteries.Count;  // OrbitalBatteries: remaining everything up to 1
-                    //if (removeOrbitalBatteries < 2)
-                    //    removeOrbitalBatteries = 0;
-                    //target.RemoveOrbitalBatteries(removeOrbitalBatteries);
-
-                    //OnUnitTargeted(target);
-
                     game.CivilizationManagers[targetCiv].SitRepEntries.Add(
                         new ScriptedEventSitRepEntry(
                             new ScriptedEventSitRepEntryData(
@@ -201,10 +159,7 @@ namespace Supremacy.Scripting.Events
                                 "vfs:///Resources/SoundFX/ScriptedEvents/Earthquake.wav",
                                 () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
 
-
-
                     GameContext.Current.Universe.UpdateSectors();
-
 
                     return;
                 }
@@ -223,6 +178,5 @@ namespace Supremacy.Scripting.Events
                 AffectedProjects.Clear();
             }
         }
-
     }
 }

--- a/SupremacyCore/Scripting/Events/GammaRayBurst.cs
+++ b/SupremacyCore/Scripting/Events/GammaRayBurst.cs
@@ -1,24 +1,20 @@
-﻿
-// Copyright (c) 2009 Mike Strobel
+﻿// Copyright (c) 2009 Mike Strobel
 //
 // This source code is subject to the terms of the Microsoft Reciprocal License (Ms-RL).
 // For details, see <http://www.opensource.org/licenses/ms-rl.html>.
 //
 // All other rights reserved.
 
-using System;
-using System.Collections.Generic;
 using Supremacy.Game;
-
-using System.Linq;
-
 using Supremacy.Universe;
 using Supremacy.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Supremacy.Scripting.Events
 {
     [Serializable]
-    //First class here deals with turning off production for one turn and reduction of population, see around line 157 158 about structures, buildings... 
     public class GammaRayBurstEvent : UnitScopedEvent<Colony>
     {
         private int _occurrenceChance = 100;
@@ -46,12 +42,6 @@ namespace Supremacy.Scripting.Events
                 }
             }
         }
-
-        //protected override void OnTurnStartedOverride(GameContext game)
-        //{
-        //    _productionFinished = false;
-        //    _shipProductionFinished = false; // turn off production for this turn
-        //}
 
         protected override void OnTurnPhaseFinishedOverride(GameContext game, TurnPhase phase)
         {
@@ -87,108 +77,25 @@ namespace Supremacy.Scripting.Events
                     if (game.Universe.FindOwned<Colony>(targetCiv).Count > 1)
                         GameLog.Client.GameData.DebugFormat("GammaRayBurstEvents.cs: colony amount > 1 for: {0}", target.Name);
 
-                    {
-                        game.CivilizationManagers[targetCiv].SitRepEntries.Add
-                            (new ScriptedEventSitRepEntry(new ScriptedEventSitRepEntryData(
-                            targetCiv,
-                                "GAMMA_RAY_BURST_HEADER_TEXT",
-                                "GAMMA_RAY_BURST_SUMMARY_TEXT",
-                                "GAMMA_RAY_BURST_DETAIL_TEXT",
-                                "vfs:///Resources/Images/ScriptedEvents/GammaRayBurst.png",
-                                "vfs:///Resources/SoundFX/ScriptedEvents/GammaRayBurst.mp3",
-                                 () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
+                    game.CivilizationManagers[targetCiv].SitRepEntries.Add
+                        (new ScriptedEventSitRepEntry(new ScriptedEventSitRepEntryData(
+                        targetCiv,
+                            "GAMMA_RAY_BURST_HEADER_TEXT",
+                            "GAMMA_RAY_BURST_SUMMARY_TEXT",
+                            "GAMMA_RAY_BURST_DETAIL_TEXT",
+                            "vfs:///Resources/Images/ScriptedEvents/GammaRayBurst.png",
+                            "vfs:///Resources/SoundFX/ScriptedEvents/GammaRayBurst.mp3",
+                                () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
 
-                        GameLog.Client.GameData.DebugFormat("GammaRayBurstEvents.cs: HomeSystemName is: {0}", target.Name);
-                        GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.AdjustCurrent(-population + 40);
-                        GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.UpdateAndReset();
-
-                        //target.Population.AdjustCurrent(); 
-                    }
-
-
-                    //Destroy(system.Colony);
-
-                    //    var affectedProjects = target.BuildSlots
-                    //    .Concat((target.Shipyard != null) ? target.Shipyard.BuildSlots : Enumerable.Empty<BuildSlot>())
-                    //    .Where(o => o.HasProject && !o.Project.IsPaused && !o.Project.IsCancelled)
-                    //    .Select(o => o.Project);
-
-                    ////foreach (var affectedProject in affectedProjects)
-                    //{
-                    //    //GameLog.Client.GameData.DebugFormat("GammaRayBurstEvents.cs: affectedProject: {0}", affectedProject.Description);
-
-                    //    //this.AffectedProjects.Add(affectedProject);
-                    //}
-
-                    //Buildings
-                    // BUNKER_NETWORK (deep in ground)
-                    // DILITHIUM_REFINERY (basic structure)
-                    // SUBSPACE_SCANNER (?)
-
-                    //List<Building> tmpBuildings = new List<Building>(target.Buildings.Count);
-                    //tmpBuildings.AddRange(target.Buildings.ToList());
-                    //tmpBuildings.ForEach(o => target.RemoveBuilding(o));
-                    //tmpBuildings.ForEach(o => o.ObjectID = GameObjectID.InvalidID);
-
-                    //GameLog.Client.GameData.DebugFormat("GammaRayBurstEvents.cs: affectedBuildings: {0}", target);
-
-                    //OnUnitTargeted(target);
-
-                    // Population
-
-                    // Facilities
-                    //int removeFood = target.GetTotalFacilities(ProductionCategory.Food) - 6; // Food: remaining everything up to 6
-                    //if (removeFood < 7)
-                    //    removeFood = 0;
-                    //target.RemoveFacilities(ProductionCategory.Food, removeFood);
-
-                    //int removeIndustry = target.GetTotalFacilities(ProductionCategory.Industry) - 5; // Industry: remaining everything up to 5
-                    //if (removeIndustry < 6)
-                    //    removeIndustry = 0;
-                    //target.RemoveFacilities(ProductionCategory.Industry, removeIndustry);
-
-                    //int removeEnergy = target.GetTotalFacilities(ProductionCategory.Energy) - 2;  // Energy: remaining everything up to 2
-                    //if (removeEnergy < 3)
-                    //    removeEnergy = 0;
-                    //target.RemoveFacilities(ProductionCategory.Energy, removeEnergy);
-
-                    //int removeResearch = target.GetTotalFacilities(ProductionCategory.Research - 3);  // Research: remaining everything up to 3
-                    //if (removeResearch < 4)
-                    //    removeResearch = 0;
-                    //target.RemoveFacilities(ProductionCategory.Research, removeResearch);
-
-                    //int removeIntelligence = target.GetTotalFacilities(ProductionCategory.Intelligence - 3);  // Research: remaining everything up to 3
-                    //if (removeIntelligence < 4)
-                    //    removeIntelligence = 0;
-                    //target.RemoveFacilities(ProductionCategory.Intelligence, removeIntelligence); // Intelligence: remaining everything up to 0
-
-                    ////// OrbitalBatteries
-                    ////int removeOrbitalBatteries = target.OrbitalBatteries.Count;  // OrbitalBatteries: remaining everything up to 1
-                    //if (removeOrbitalBatteries < 2)
-                    //    removeOrbitalBatteries = 0;
-                    //target.RemoveOrbitalBatteries(removeOrbitalBatteries);
-
-                    //OnUnitTargeted(target);
+                    GameLog.Client.GameData.DebugFormat("GammaRayBurstEvents.cs: HomeSystemName is: {0}", target.Name);
+                    GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.AdjustCurrent(-population + 40);
+                    GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.UpdateAndReset();
 
                     GameContext.Current.Universe.UpdateSectors();
 
                     return;
                 }
-
-                //if (phase == TurnPhase.Production)
-                //    _productionFinished = true; // turn production back on
-                //else if (phase == TurnPhase.ShipProduction)
-                //    _shipProductionFinished = true;
-
-                //if (!_productionFinished || !_shipProductionFinished)
-                //    return;
-
-                //foreach (var affectedProject in this.AffectedProjects)
-                //    affectedProject.IsPaused = false;
-
-                //this.AffectedProjects.Clear();
             }
         }
-
     }
 }

--- a/SupremacyCore/Scripting/Events/PlagueEvent.cs
+++ b/SupremacyCore/Scripting/Events/PlagueEvent.cs
@@ -1,24 +1,20 @@
-﻿
-// Copyright (c) 2009 Mike Strobel
+﻿// Copyright (c) 2009 Mike Strobel
 //
 // This source code is subject to the terms of the Microsoft Reciprocal License (Ms-RL).
 // For details, see <http://www.opensource.org/licenses/ms-rl.html>.
 //
 // All other rights reserved.
 
-using System;
-using System.Collections.Generic;
 using Supremacy.Game;
-
-using System.Linq;
-
 using Supremacy.Universe;
 using Supremacy.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Supremacy.Scripting.Events
 {
     [Serializable]
-    //First class here deals with turning off production for one turn and reduction of population, see around line 157 158 about structures, buildings... 
     public class PlagueEvent : UnitScopedEvent<Colony>
     {
 
@@ -49,12 +45,6 @@ namespace Supremacy.Scripting.Events
             }
         }
 
-        //protected override void OnTurnStartedOverride(GameContext game)
-        //{
-        //    _productionFinished = false;
-        //    _shipProductionFinished = false; // turn off production for this turn
-        //}
-
         protected override void OnTurnPhaseFinishedOverride(GameContext game, TurnPhase phase)
         {
             if (phase == TurnPhase.PreTurnOperations)
@@ -77,7 +67,6 @@ namespace Supremacy.Scripting.Events
                     var productionCenters = group.ToList();
 
                     var target = productionCenters[RandomProvider.Next(productionCenters.Count)];
-                    //GameLog.Client.GameData.DebugFormat("PlagueEvents.cs: target.Name: {0}", target.Name);
 
                     if (target.Name == "Sol" || target.Name == "Terra" || target.Name == "Cardassia" || target.Name == "Qo'nos" || target.Name == "Omarion Nebula" || target.Name == "Romulus" || target.Name == "Borg Nebula")
                         return;
@@ -86,126 +75,28 @@ namespace Supremacy.Scripting.Events
                     int targetColonyId = target.ObjectID;
                     var population = target.Population.CurrentValue;
 
-                    //var system = item as StarSystem;
-                    //if (system != null)
-                    //{
-                    //    if (system.IsInhabited)
                     if (game.Universe.FindOwned<Colony>(targetCiv).Count > 1)
                         GameLog.Client.GameData.DebugFormat("PlagueEvents.cs: colony amount > 1 for: {0}", target.Name);
 
-                    {
-                        game.CivilizationManagers[targetCiv].SitRepEntries.Add
-                            (new ScriptedEventSitRepEntry(new ScriptedEventSitRepEntryData(
-                            targetCiv,
-                                "PLAGUE_HEADER_TEXT",
-                                "PLAGUE_SUMMARY_TEXT",
-                                "PLAGUE_DETAIL_TEXT",
-                                "vfs:///Resources/Images/ScriptedEvents/Plague.png",
-                                "vfs:///Resources/SoundFX/ScriptedEvents/Plague.mp3",
-                                 () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
+                    game.CivilizationManagers[targetCiv].SitRepEntries.Add
+                        (new ScriptedEventSitRepEntry(new ScriptedEventSitRepEntryData(
+                        targetCiv,
+                            "PLAGUE_HEADER_TEXT",
+                            "PLAGUE_SUMMARY_TEXT",
+                            "PLAGUE_DETAIL_TEXT",
+                            "vfs:///Resources/Images/ScriptedEvents/Plague.png",
+                            "vfs:///Resources/SoundFX/ScriptedEvents/Plague.mp3",
+                                () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
 
-                        GameLog.Client.GameData.DebugFormat("PlagueEvents.cs: HomeSystemName is: {0}", target.Name);
-                        GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.AdjustCurrent(- population + 50);
-                        GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.UpdateAndReset();
-
-                        //target.Population.AdjustCurrent(); 
-                    }
-
-
-
-                    //Destroy(system.Colony);
-
-
-                    //    var affectedProjects = target.BuildSlots
-                    //    .Concat((target.Shipyard != null) ? target.Shipyard.BuildSlots : Enumerable.Empty<BuildSlot>())
-                    //    .Where(o => o.HasProject && !o.Project.IsPaused && !o.Project.IsCancelled)
-                    //    .Select(o => o.Project);
-
-                    ////foreach (var affectedProject in affectedProjects)
-                    //{
-                    //    //GameLog.Client.GameData.DebugFormat("PlagueEvents.cs: affectedProject: {0}", affectedProject.Description);
-
-
-                    //    //this.AffectedProjects.Add(affectedProject);
-                    //}
-
-
-
-                    //Buildings
-                    // BUNKER_NETWORK (deep in ground)
-                    // DILITHIUM_REFINERY (basic structure)
-                    // SUBSPACE_SCANNER (?)
-
-                    //List<Building> tmpBuildings = new List<Building>(target.Buildings.Count);
-                    //tmpBuildings.AddRange(target.Buildings.ToList());
-                    //tmpBuildings.ForEach(o => target.RemoveBuilding(o));
-                    //tmpBuildings.ForEach(o => o.ObjectID = GameObjectID.InvalidID);
-
-                    //GameLog.Client.GameData.DebugFormat("PlagueEvents.cs: affectedBuildings: {0}", target);
-
-                    //OnUnitTargeted(target);
-
-                    // Population
-
-
-                    // Facilities
-                    //int removeFood = target.GetTotalFacilities(ProductionCategory.Food) - 6; // Food: remaining everything up to 6
-                    //if (removeFood < 7)
-                    //    removeFood = 0;
-                    //target.RemoveFacilities(ProductionCategory.Food, removeFood);
-
-                    //int removeIndustry = target.GetTotalFacilities(ProductionCategory.Industry) - 5; // Industry: remaining everything up to 5
-                    //if (removeIndustry < 6)
-                    //    removeIndustry = 0;
-                    //target.RemoveFacilities(ProductionCategory.Industry, removeIndustry);
-
-                    //int removeEnergy = target.GetTotalFacilities(ProductionCategory.Energy) - 2;  // Energy: remaining everything up to 2
-                    //if (removeEnergy < 3)
-                    //    removeEnergy = 0;
-                    //target.RemoveFacilities(ProductionCategory.Energy, removeEnergy);
-
-                    //int removeResearch = target.GetTotalFacilities(ProductionCategory.Research - 3);  // Research: remaining everything up to 3
-                    //if (removeResearch < 4)
-                    //    removeResearch = 0;
-                    //target.RemoveFacilities(ProductionCategory.Research, removeResearch);
-
-                    //int removeIntelligence = target.GetTotalFacilities(ProductionCategory.Intelligence - 3);  // Research: remaining everything up to 3
-                    //if (removeIntelligence < 4)
-                    //    removeIntelligence = 0;
-                    //target.RemoveFacilities(ProductionCategory.Intelligence, removeIntelligence); // Intelligence: remaining everything up to 0
-
-                    ////// OrbitalBatteries
-                    ////int removeOrbitalBatteries = target.OrbitalBatteries.Count;  // OrbitalBatteries: remaining everything up to 1
-                    //if (removeOrbitalBatteries < 2)
-                    //    removeOrbitalBatteries = 0;
-                    //target.RemoveOrbitalBatteries(removeOrbitalBatteries);
-
-                    //OnUnitTargeted(target);
-
-
-
-
+                    GameLog.Client.GameData.DebugFormat("PlagueEvents.cs: HomeSystemName is: {0}", target.Name);
+                    GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.AdjustCurrent(- population + 50);
+                    GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.UpdateAndReset();
 
                     GameContext.Current.Universe.UpdateSectors();
 
-
                     return;
                 }
-
-                //if (phase == TurnPhase.Production)
-                //    _productionFinished = true; // turn production back on
-                //else if (phase == TurnPhase.ShipProduction)
-                //    _shipProductionFinished = true;
-
-                //if (!_productionFinished || !_shipProductionFinished)
-                //    return;
-
-                //foreach (var affectedProject in this.AffectedProjects)
-                //    affectedProject.IsPaused = false;
-
-                //this.AffectedProjects.Clear();
             }
         }
-
     }
 }

--- a/SupremacyCore/Scripting/Events/ReligiousHolidayEvent.cs
+++ b/SupremacyCore/Scripting/Events/ReligiousHolidayEvent.cs
@@ -1,5 +1,3 @@
-// ReligiousHolidayEvent.cs
-//
 // Copyright (c) 2009 Mike Strobel
 //
 // This source code is subject to the terms of the Microsoft Reciprocal License (Ms-RL).
@@ -7,16 +5,13 @@
 //
 // All other rights reserved.
 
-using System;
-using System.Collections.Generic;
-
 using Supremacy.Economy;
 using Supremacy.Game;
-
-using System.Linq;
-
 using Supremacy.Universe;
 using Supremacy.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Supremacy.Scripting.Events
 {
@@ -99,7 +94,7 @@ namespace Supremacy.Scripting.Events
 
                     var target = productionCenters[RandomProvider.Next(productionCenters.Count)];
 
-                    if (target.Owner.Name == "Borg") // Borg do not have strikes
+                    if (target.Owner.Name == "Borg") // Borg do not have religious holidays
                         return;
 
                     if (target.Name == "Omarion")
@@ -118,23 +113,21 @@ namespace Supremacy.Scripting.Events
 
                     var targetCiv = target.Owner;
                     int targetColonyId = target.ObjectID;
-                    //target.Destroy();
+
                     OnUnitTargeted(target);
 
-                    {
-                        GameContext.Current.Universe.Get<Colony>(targetColonyId).Morale.AdjustCurrent(+5);
-                        GameContext.Current.Universe.Get<Colony>(targetColonyId).Morale.UpdateAndReset();
-                        game.CivilizationManagers[targetCiv].SitRepEntries.Add(
-                            new ScriptedEventSitRepEntry(
-                                new ScriptedEventSitRepEntryData(
-                                    targetCiv,
-                                    "RELIGIOUS_HOLIDAY_HEADER_TEXT",
-                                    "RELIGIOUS_HOLIDAY_SUMMARY_TEXT",
-                                    "RELIGIOUS_HOLIDAY_DETAIL_TEXT",
-                                    "vfs:///Resources/Images/ScriptedEvents/ReligiousHoliday.png",
-                                    "vfs:///Resources/SoundFX/ScriptedEvents/ReligiousHoliday.wma",
-                                    () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
-                    }
+                    GameContext.Current.Universe.Get<Colony>(targetColonyId).Morale.AdjustCurrent(+5);
+                    GameContext.Current.Universe.Get<Colony>(targetColonyId).Morale.UpdateAndReset();
+                    game.CivilizationManagers[targetCiv].SitRepEntries.Add(
+                        new ScriptedEventSitRepEntry(
+                            new ScriptedEventSitRepEntryData(
+                                targetCiv,
+                                "RELIGIOUS_HOLIDAY_HEADER_TEXT",
+                                "RELIGIOUS_HOLIDAY_SUMMARY_TEXT",
+                                "RELIGIOUS_HOLIDAY_DETAIL_TEXT",
+                                "vfs:///Resources/Images/ScriptedEvents/ReligiousHoliday.png",
+                                "vfs:///Resources/SoundFX/ScriptedEvents/ReligiousHoliday.wma",
+                                () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
                 }
 
                 return;

--- a/SupremacyCore/Scripting/Events/Supernovai.cs
+++ b/SupremacyCore/Scripting/Events/Supernovai.cs
@@ -1,24 +1,20 @@
-﻿
-// Copyright (c) 2009 Mike Strobel
+﻿// Copyright (c) 2009 Mike Strobel
 //
 // This source code is subject to the terms of the Microsoft Reciprocal License (Ms-RL).
 // For details, see <http://www.opensource.org/licenses/ms-rl.html>.
 //
 // All other rights reserved.
 
-using System;
-using System.Collections.Generic;
 using Supremacy.Game;
-
-using System.Linq;
-
 using Supremacy.Universe;
 using Supremacy.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Supremacy.Scripting.Events
 {
     [Serializable]
-    //First class here deals with turning off production for one turn and reduction of population, see around line 157 158 about structures, buildings... 
     public class SupernovaiEvent : UnitScopedEvent<Colony>
     {
         
@@ -48,12 +44,6 @@ namespace Supremacy.Scripting.Events
             }
         }
 
-        //protected override void OnTurnStartedOverride(GameContext game)
-        //{
-        //    _productionFinished = false;
-        //    _shipProductionFinished = false; // turn off production for this turn
-        //}
-
         protected override void OnTurnPhaseFinishedOverride(GameContext game, TurnPhase phase)
         {
             if (phase == TurnPhase.PreTurnOperations)
@@ -76,7 +66,6 @@ namespace Supremacy.Scripting.Events
                     var productionCenters = group.ToList();
 
                     var target = productionCenters[RandomProvider.Next(productionCenters.Count)];
-                    //GameLog.Client.GameData.DebugFormat("SupernovaiEvents.cs: target.Name: {0}", target.Name);
 
                     if (target.Name == "Sol" || target.Name == "Terra" || target.Name == "Cardassia" || target.Name == "Qo'nos" || target.Name == "Omarion Nebula" || target.Name == "Romulus" || target.Name == "Borg Nebula")
                         return;
@@ -85,126 +74,28 @@ namespace Supremacy.Scripting.Events
                     int targetColonyId = target.ObjectID;
                     var population = target.Population.CurrentValue;
 
-                    //var system = item as StarSystem;
-                    //if (system != null)
-                    //{
-                    //    if (system.IsInhabited)
                     if (game.Universe.FindOwned<Colony>(targetCiv).Count > 1) 
                         GameLog.Client.GameData.DebugFormat("SupernovaiEvents.cs: colony amount > 1 for: {0}", target.Name);
 
-                    {
-                        game.CivilizationManagers[targetCiv].SitRepEntries.Add
-                            (new ScriptedEventSitRepEntry(new ScriptedEventSitRepEntryData(
-                            targetCiv,
-                                "SUPERNOVA_I_HEADER_TEXT",
-                                "SUPERNOVA_I_SUMMARY_TEXT",
-                                "SUPERNOVA_I_DETAIL_TEXT",
-                                "vfs:///Resources/Images/ScriptedEvents/Supernovai.png",
-                                "vfs:///Resources/SoundFX/ScriptedEvents/Supernovai.wav",
-                                 () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
+                    game.CivilizationManagers[targetCiv].SitRepEntries.Add
+                        (new ScriptedEventSitRepEntry(new ScriptedEventSitRepEntryData(
+                        targetCiv,
+                            "SUPERNOVA_I_HEADER_TEXT",
+                            "SUPERNOVA_I_SUMMARY_TEXT",
+                            "SUPERNOVA_I_DETAIL_TEXT",
+                            "vfs:///Resources/Images/ScriptedEvents/Supernovai.png",
+                            "vfs:///Resources/SoundFX/ScriptedEvents/Supernovai.wav",
+                                () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
 
-                        GameLog.Client.GameData.DebugFormat("SupernovaiEvents.cs: HomeSystemName is: {0}", target.Name);
-                        GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.AdjustCurrent(-population + 30);
-                        GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.UpdateAndReset();
-
-                        //target.Population.AdjustCurrent(); 
-                            }
-
-
-
-                    //Destroy(system.Colony);
-
-
-                    //    var affectedProjects = target.BuildSlots
-                    //    .Concat((target.Shipyard != null) ? target.Shipyard.BuildSlots : Enumerable.Empty<BuildSlot>())
-                    //    .Where(o => o.HasProject && !o.Project.IsPaused && !o.Project.IsCancelled)
-                    //    .Select(o => o.Project);
-
-                    ////foreach (var affectedProject in affectedProjects)
-                    //{
-                    //    //GameLog.Client.GameData.DebugFormat("SupernovaiEvents.cs: affectedProject: {0}", affectedProject.Description);
-
-
-                    //    //this.AffectedProjects.Add(affectedProject);
-                    //}
-
-
-
-                    //Buildings
-                    // BUNKER_NETWORK (deep in ground)
-                    // DILITHIUM_REFINERY (basic structure)
-                    // SUBSPACE_SCANNER (?)
-
-                    //List<Building> tmpBuildings = new List<Building>(target.Buildings.Count);
-                    //tmpBuildings.AddRange(target.Buildings.ToList());
-                    //tmpBuildings.ForEach(o => target.RemoveBuilding(o));
-                    //tmpBuildings.ForEach(o => o.ObjectID = GameObjectID.InvalidID);
-
-                    //GameLog.Client.GameData.DebugFormat("SupernovaiEvents.cs: affectedBuildings: {0}", target);
-
-                    //OnUnitTargeted(target);
-
-                    // Population
-
-
-                    // Facilities
-                    //int removeFood = target.GetTotalFacilities(ProductionCategory.Food) - 6; // Food: remaining everything up to 6
-                    //if (removeFood < 7)
-                    //    removeFood = 0;
-                    //target.RemoveFacilities(ProductionCategory.Food, removeFood);
-
-                    //int removeIndustry = target.GetTotalFacilities(ProductionCategory.Industry) - 5; // Industry: remaining everything up to 5
-                    //if (removeIndustry < 6)
-                    //    removeIndustry = 0;
-                    //target.RemoveFacilities(ProductionCategory.Industry, removeIndustry);
-
-                    //int removeEnergy = target.GetTotalFacilities(ProductionCategory.Energy) - 2;  // Energy: remaining everything up to 2
-                    //if (removeEnergy < 3)
-                    //    removeEnergy = 0;
-                    //target.RemoveFacilities(ProductionCategory.Energy, removeEnergy);
-
-                    //int removeResearch = target.GetTotalFacilities(ProductionCategory.Research - 3);  // Research: remaining everything up to 3
-                    //if (removeResearch < 4)
-                    //    removeResearch = 0;
-                    //target.RemoveFacilities(ProductionCategory.Research, removeResearch);
-
-                    //int removeIntelligence = target.GetTotalFacilities(ProductionCategory.Intelligence - 3);  // Research: remaining everything up to 3
-                    //if (removeIntelligence < 4)
-                    //    removeIntelligence = 0;
-                    //target.RemoveFacilities(ProductionCategory.Intelligence, removeIntelligence); // Intelligence: remaining everything up to 0
-
-                    ////// OrbitalBatteries
-                    ////int removeOrbitalBatteries = target.OrbitalBatteries.Count;  // OrbitalBatteries: remaining everything up to 1
-                    //if (removeOrbitalBatteries < 2)
-                    //    removeOrbitalBatteries = 0;
-                    //target.RemoveOrbitalBatteries(removeOrbitalBatteries);
-
-                    //OnUnitTargeted(target);
-
-
-
-
+                    GameLog.Client.GameData.DebugFormat("SupernovaiEvents.cs: HomeSystemName is: {0}", target.Name);
+                    GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.AdjustCurrent(-population + 30);
+                    GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.UpdateAndReset();
 
                     GameContext.Current.Universe.UpdateSectors();
 
-
                     return;
                 }
-
-                //if (phase == TurnPhase.Production)
-                //    _productionFinished = true; // turn production back on
-                //else if (phase == TurnPhase.ShipProduction)
-                //    _shipProductionFinished = true;
-
-                //if (!_productionFinished || !_shipProductionFinished)
-                //    return;
-
-                //foreach (var affectedProject in this.AffectedProjects)
-                //    affectedProject.IsPaused = false;
-
-                //this.AffectedProjects.Clear();
             }
         }
-
     }
 }

--- a/SupremacyCore/Scripting/Events/TerroristBombingOfShipProduction.cs
+++ b/SupremacyCore/Scripting/Events/TerroristBombingOfShipProduction.cs
@@ -1,27 +1,22 @@
-﻿
-// Copyright (c) 2009 Mike Strobel
+﻿// Copyright (c) 2009 Mike Strobel
 //
 // This source code is subject to the terms of the Microsoft Reciprocal License (Ms-RL).
 // For details, see <http://www.opensource.org/licenses/ms-rl.html>.
 //
 // All other rights reserved.
 
-using System;
-using System.Collections.Generic;
-
+using Supremacy.Buildings;
 using Supremacy.Economy;
 using Supremacy.Game;
-
-using System.Linq;
-
 using Supremacy.Universe;
 using Supremacy.Utility;
-using Supremacy.Buildings;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Supremacy.Scripting.Events
 {
     [Serializable]
-    //First class here deals with turning off production for one turn and reduction of population, see around line 157 158 about structures, buildings... 
     public class TerroristBombingOfShipProductionEvent : UnitScopedEvent<Colony>
     {
         private bool _productionFinished;
@@ -30,7 +25,6 @@ namespace Supremacy.Scripting.Events
 
         [NonSerialized]
         private List<BuildProject> _affectedProjects;
-        //private List<BuildProject> _asteroidImpactUnits;
         protected List<BuildProject> AffectedProjects
         {
             get
@@ -40,8 +34,8 @@ namespace Supremacy.Scripting.Events
                 return _affectedProjects;
             }
         }
+
         private List<Building> _affectedBuildings;
-        //private List<BuildProject> _asteroidImpactUnits;
         protected List<Building> AffectedBuildings
         {
             get
@@ -52,12 +46,10 @@ namespace Supremacy.Scripting.Events
             }
         }
 
-
         public TerroristBombingOfShipProductionEvent()
         {
             _affectedProjects = new List<BuildProject>();
             _affectedBuildings = new List<Building>();
-            //_asteroidImpactUnits = new List<AsteroidImpactUnit>();
         }
 
         public override bool CanExecute
@@ -134,12 +126,6 @@ namespace Supremacy.Scripting.Events
                     int targetColonyId = target.ObjectID;
                     var population = target.Population.CurrentValue;
 
-                    //Buildings
-                    // BUNKER_NETWORK (deep in ground)
-                    // DILITHIUM_REFINERY (basic structure)
-                    // SUBSPACE_SCANNER (?)
-                    // Shipyard = Buildslot
-
                     if (target.Shipyard != null)
                     {
                         GameLog.Client.GameData.DebugFormat("TerroristBombShipyards.cs: {0} Shipyard: {1}, affectedProject: {2}", target.Name, target.Shipyard.Name, target.Shipyard.BuildSlots.Count);
@@ -163,48 +149,6 @@ namespace Supremacy.Scripting.Events
 
                     OnUnitTargeted(target);
 
-                    // Population
-                    //GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.AdjustCurrent(-population + 75);
-                    //GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.UpdateAndReset();
-
-                    //// Facilities
-                    //int removeFood = target.GetTotalFacilities(ProductionCategory.Food) - 6; // Food: remaining everything up to 6
-                    //if (removeFood < 7)
-                    //    removeFood = 0;
-                    //target.RemoveFacilities(ProductionCategory.Food, removeFood);
-
-                    //int removeIndustry = target.GetTotalFacilities(ProductionCategory.Industry) - 5; // Industry: remaining everything up to 5
-                    //if (removeIndustry < 6)
-                    //    removeIndustry = 0;
-                    //target.RemoveFacilities(ProductionCategory.Industry, removeIndustry);
-
-                    //int removeEnergy = target.GetTotalFacilities(ProductionCategory.Energy) - 2;  // Energy: remaining everything up to 2
-                    //if (removeEnergy < 3)
-                    //    removeEnergy = 0;
-                    //target.RemoveFacilities(ProductionCategory.Energy, removeEnergy);
-
-                    //int removeResearch = target.GetTotalFacilities(ProductionCategory.Research - 3);  // Research: remaining everything up to 3
-                    //if (removeResearch < 4)
-                    //    removeResearch = 0;
-                    //target.RemoveFacilities(ProductionCategory.Research, removeResearch);
-
-                    //int removeIntelligence = target.GetTotalFacilities(ProductionCategory.Intelligence - 3);  // Research: remaining everything up to 3
-                    //if (removeIntelligence < 4)
-                    //    removeIntelligence = 0;
-                    //target.RemoveFacilities(ProductionCategory.Intelligence, removeIntelligence); // Intelligence: remaining everything up to 0
-
-                    //// OrbitalBatteries
-                    //int removeOrbitalBatteries = target.OrbitalBatteries.Count;  // OrbitalBatteries: remaining everything up to 1
-                    //if (removeOrbitalBatteries < 2)
-                    //    removeOrbitalBatteries = 0;
-                    //target.RemoveOrbitalBatteries(removeOrbitalBatteries);
-
-                    //OnUnitTargeted(target);
-
-                    //if (target.Shipyard == null)
-                    //    return;
-                    //else
-
                     GameContext.Current.Universe.UpdateSectors();
 
                 }
@@ -223,6 +167,5 @@ namespace Supremacy.Scripting.Events
                 AffectedProjects.Clear();
             }
         }
-
     }
 }

--- a/SupremacyCore/Scripting/Events/TerroristsCaptured.cs
+++ b/SupremacyCore/Scripting/Events/TerroristsCaptured.cs
@@ -1,47 +1,23 @@
-﻿// TerroristsCaptured.cs
-//
-// Copyright (c) 2009 Mike Strobel
+﻿// Copyright (c) 2009 Mike Strobel
 //
 // This source code is subject to the terms of the Microsoft Reciprocal License (Ms-RL).
 // For details, see <http://www.opensource.org/licenses/ms-rl.html>.
 //
 // All other rights reserved.
 
-using System;
-using System.Collections.Generic;
 using Supremacy.Game;
-
-using System.Linq;
-
 using Supremacy.Universe;
 using Supremacy.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Supremacy.Scripting.Events
 {
     [Serializable]
     public class TerroristsCaptured : UnitScopedEvent<Colony>
     {
-        //private bool _productionFinished;
-        //private bool _shipProductionFinished;
         private int _occurrenceChance = 100;
-
-        //[NonSerialized]
-        //private List<BuildProject> _affectedProjects;
-
-        //protected List<BuildProject> AffectedProjects
-        //{
-        //    get
-        //    {
-        //        if (_affectedProjects == null)
-        //            _affectedProjects = new List<BuildProject>();
-        //        return _affectedProjects;
-        //    }
-        //}
-
-        //public TerroristsCaptured()
-        //{
-        //    _affectedProjects = new List<BuildProject>();
-        //}
 
         public override bool CanExecute
         {
@@ -68,12 +44,6 @@ namespace Supremacy.Scripting.Events
             }
         }
 
-        //protected override void OnTurnStartedOverride(GameContext game)
-        //{
-        //    _productionFinished = false;
-        //    _shipProductionFinished = false;
-        //}
-
         protected override void OnTurnPhaseFinishedOverride(GameContext game, TurnPhase phase)
         {
             if (phase == TurnPhase.PreTurnOperations)
@@ -98,56 +68,30 @@ namespace Supremacy.Scripting.Events
 
                     var target = productionCenters[RandomProvider.Next(productionCenters.Count)];
 
-                    if (target.Owner.Name == "Borg") // Borg do not have strikes
+                    if (target.Owner.Name == "Borg") // Borg do not have terrorists
                         return;
-                    //var affectedProjects = target.BuildSlots
-                    //    .Concat((target.Shipyard != null) ? target.Shipyard.BuildSlots : Enumerable.Empty<BuildSlot>())
-                    //    .Where(o => o.HasProject && !o.Project.IsPaused && !o.Project.IsCancelled)
-                    //    .Select(o => o.Project);
-
-                    //foreach (var affectedProject in affectedProjects)
-                    //{
-                    //    affectedProject.IsPaused = true;
-                    //    this.AffectedProjects.Add(affectedProject);
-                    //}
 
                     var targetCiv = target.Owner;
                     int targetColonyId = target.ObjectID;
-                    //target.Destroy();
                     OnUnitTargeted(target);
 
-                    {
-                        GameContext.Current.Universe.Get<Colony>(targetColonyId).Morale.AdjustCurrent(+5);
-                        GameContext.Current.Universe.Get<Colony>(targetColonyId).Morale.UpdateAndReset();
+                    GameContext.Current.Universe.Get<Colony>(targetColonyId).Morale.AdjustCurrent(+5);
+                    GameContext.Current.Universe.Get<Colony>(targetColonyId).Morale.UpdateAndReset();
 
-                        game.CivilizationManagers[targetCiv].SitRepEntries.Add(
-                            new ScriptedEventSitRepEntry(
-                                new ScriptedEventSitRepEntryData(
-                                    targetCiv,
-                                    "TERRORISTS_CAPTURED_HEADER_TEXT",
-                                    "TERRORISTS_CAPTURED_SUMMARY_TEXT",
-                                    "TERRORISTS_CAPTURED_DETAIL_TEXT",
-                                    "vfs:///Resources/Images/ScriptedEvents/TerroristsCaptured.png",
-                                    "vfs:///Resources/SoundFX/ScriptedEvents/EventGenerell.wma",
-                                    () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
-                    }
+                    game.CivilizationManagers[targetCiv].SitRepEntries.Add(
+                        new ScriptedEventSitRepEntry(
+                            new ScriptedEventSitRepEntryData(
+                                targetCiv,
+                                "TERRORISTS_CAPTURED_HEADER_TEXT",
+                                "TERRORISTS_CAPTURED_SUMMARY_TEXT",
+                                "TERRORISTS_CAPTURED_DETAIL_TEXT",
+                                "vfs:///Resources/Images/ScriptedEvents/TerroristsCaptured.png",
+                                "vfs:///Resources/SoundFX/ScriptedEvents/EventGenerell.wma",
+                                () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
                 }
 
                 return;
             }
-
-            //if (phase == TurnPhase.Production)
-            //    _productionFinished = true;
-            //else if (phase == TurnPhase.ShipProduction)
-            //    _shipProductionFinished = true;
-
-            //if (!_productionFinished || !_shipProductionFinished)
-            //    return;
-
-            //foreach (var affectedProject in this.AffectedProjects)
-            //    affectedProject.IsPaused = false;
-
-            //this.AffectedProjects.Clear();
         }
     }
 }

--- a/SupremacyCore/Scripting/Events/TradeGuildStrikes.cs
+++ b/SupremacyCore/Scripting/Events/TradeGuildStrikes.cs
@@ -1,22 +1,17 @@
-﻿// TradeGuildStikes.cs
-//
-// Copyright (c) 2009 Mike Strobel
+﻿// Copyright (c) 2009 Mike Strobel
 //
 // This source code is subject to the terms of the Microsoft Reciprocal License (Ms-RL).
 // For details, see <http://www.opensource.org/licenses/ms-rl.html>.
 //
 // All other rights reserved.
 
-using System;
-using System.Collections.Generic;
-
 using Supremacy.Economy;
 using Supremacy.Game;
-
-using System.Linq;
-
 using Supremacy.Universe;
 using Supremacy.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Supremacy.Scripting.Events
 {
@@ -113,12 +108,9 @@ namespace Supremacy.Scripting.Events
 
                     foreach (var affectedProject in affectedProjects)
                     {
-
-                        {
-                            affectedProject.IsPaused = true;
-                            AffectedProjects.Add(affectedProject);
-                            GameLog.Client.GameData.DebugFormat("TradeGuildStrkes.cs: affectedProject: {0}", affectedProject);
-                        }
+                        affectedProject.IsPaused = true;
+                        AffectedProjects.Add(affectedProject);
+                        GameLog.Client.GameData.DebugFormat("TradeGuildStrkes.cs: affectedProject: {0}", affectedProject);
                     }
 
                     var targetCiv = target.Owner;
@@ -127,18 +119,16 @@ namespace Supremacy.Scripting.Events
 
                     OnUnitTargeted(target);
 
-                    {
-                        game.CivilizationManagers[targetCiv].SitRepEntries.Add(
-                        new ScriptedEventSitRepEntry(
-                            new ScriptedEventSitRepEntryData(
-                                targetCiv,
-                                "TRADE_GUILD_STRIKES_HEADER_TEXT",
-                                "TRADE_GUILD_STRIKES_SUMMARY_TEXT",
-                                "TRADE_GUILD_STRIKES_DETAIL_TEXT",
-                                "vfs:///Resources/Images/ScriptedEvents/TradeGuildStrikes.png",
-                                "vfs:///Resources/SoundFX/ScriptedEvents/ReligiousHoliday.wma",
-                                () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
-                    }
+                    game.CivilizationManagers[targetCiv].SitRepEntries.Add(
+                    new ScriptedEventSitRepEntry(
+                        new ScriptedEventSitRepEntryData(
+                            targetCiv,
+                            "TRADE_GUILD_STRIKES_HEADER_TEXT",
+                            "TRADE_GUILD_STRIKES_SUMMARY_TEXT",
+                            "TRADE_GUILD_STRIKES_DETAIL_TEXT",
+                            "vfs:///Resources/Images/ScriptedEvents/TradeGuildStrikes.png",
+                            "vfs:///Resources/SoundFX/ScriptedEvents/ReligiousHoliday.wma",
+                            () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
                 }
 
                 return;

--- a/SupremacyCore/Scripting/Events/Tribbles.cs
+++ b/SupremacyCore/Scripting/Events/Tribbles.cs
@@ -1,27 +1,22 @@
-﻿
-// Copyright (c) 2009 Mike Strobel
+﻿// Copyright (c) 2009 Mike Strobel
 //
 // This source code is subject to the terms of the Microsoft Reciprocal License (Ms-RL).
 // For details, see <http://www.opensource.org/licenses/ms-rl.html>.
 //
 // All other rights reserved.
 
-using System;
-using System.Collections.Generic;
-
+using Supremacy.Buildings;
 using Supremacy.Economy;
 using Supremacy.Game;
-
-using System.Linq;
-
 using Supremacy.Universe;
 using Supremacy.Utility;
-using Supremacy.Buildings;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Supremacy.Scripting.Events
 {
     [Serializable]
-    //First class here deals with turning off production for one turn and reduction of population, see around line 157 158 about structures, buildings... 
     public class TribblesEvent : UnitScopedEvent<Colony>
     {
         private bool _productionFinished;
@@ -30,7 +25,6 @@ namespace Supremacy.Scripting.Events
 
         [NonSerialized]
         private List<BuildProject> _affectedProjects;
-        //private List<BuildProject> _asteroidImpactUnits;
         protected List<BuildProject> AffectedProjects
         {
             get
@@ -40,8 +34,8 @@ namespace Supremacy.Scripting.Events
                 return _affectedProjects;
             }
         }
+
         private List<Building> _affectedBuildings;
-        //private List<BuildProject> _asteroidImpactUnits;
         protected List<Building> AffectedBuildings
         {
             get
@@ -56,7 +50,6 @@ namespace Supremacy.Scripting.Events
         {
             _affectedProjects = new List<BuildProject>();
             _affectedBuildings = new List<Building>();
-            //_asteroidImpactUnits = new List<AsteroidImpactUnit>();
         }
 
         public override bool CanExecute
@@ -115,93 +108,21 @@ namespace Supremacy.Scripting.Events
                     GameLog.Client.GameData.DebugFormat("Tribbles.cs: target.Name: {0}", target.Name);
                     GameLog.Client.GameData.DebugFormat("Tribbles.cs:ProductionOutput(ProductionCategory.Food): {0}", target.GetProductionOutput(ProductionCategory.Food));
 
-                    //if (target.Name == "Sol" || target.Name == "Terra" || target.Name == "Cardassia" || target.Name == "Qo'nos" || target.Name == "Omarion Nebula" || target.Name == "Romulus" || target.Name == "Borg Nebula")
-                    //    return;
-
-                    //var affectedProjects = target.BuildSlots
-                    //.Concat((target.Shipyard != null) ? target.Shipyard.BuildSlots : Enumerable.Empty<BuildSlot>())
-                    //.Where(o => o.HasProject && !o.Project.IsPaused && !o.Project.IsCancelled)
-                    //.Select(o => o.Project);
-
-                    //foreach (var affectedProject in affectedProjects)
-                    //{
-                    //    affectedProject.IsPaused = true;
-                    //    GameLog.Client.GameData.DebugFormat("Tribbles.cs: affectedBuildings: {0}", affectedProject);
-                    //    GameLog.Client.GameData.DebugFormat("Tribbles.cs:ProductionOutput(ProductionCategory.Food): {0}", target.GetProductionOutput(ProductionCategory.Food));
-                    //    target.DeactivateFacility(ProductionCategory.Food);
-                    //    this.AffectedProjects.Add(affectedProject);
-                    //}
-
                     var targetCiv = target.Owner;
                     int targetColonyId = target.ObjectID;
                     var population = target.Population.CurrentValue;
 
-                    //Buildings
-                    // BUNKER_NETWORK (deep in ground)
-                    // DILITHIUM_REFINERY (basic structure)
-                    // SUBSPACE_SCANNER (?)
-
                     List<Building> tmpBuildings = new List<Building>(target.Buildings.Count);
                     tmpBuildings.AddRange(target.Buildings.ToList());
                     tmpBuildings.ForEach(o => target.DeactivateFacility(ProductionCategory.Food));
-                    //tmpBuildings.ForEach(o => o.ObjectID = GameObjectID.InvalidID);
 
-                    //OnUnitTargeted(target);
-
-                    //Food Production
-                    //int removeFoodReserves = target.FoodReserves.CurrentValue;
-                    //GameContext.Current.Universe.Get<Colony>(targetColonyId).FoodReserves.AdjustCurrent(0 - removeFoodReserves - 200);
-                    //GameContext.Current.Universe.Get<Colony>(targetColonyId).FoodReserves.UpdateAndReset();
-                    //GameLog.Client.GameData.DebugFormat("Tribbles.cs: FoodReserves: {0}, removeFoodReserves: {1}", GameContext.Current.Universe.Get<Colony>(targetColonyId).FoodReserves.CurrentValue, removeFoodReserves);
-
-
-                    //foodDeficitByEvent
-                    //int foodDeficitByEvent = 0;
                     GameLog.Client.GameData.DebugFormat("Tribbles.cs: target.FoodReserves before : {0}", target.FoodReserves);
-                    //foodDeficitByEvent = (target.FoodReserves.CurrentValue + target.GetProductionOutput(ProductionCategory.Food));
 
                     target.FoodReserves.AdjustCurrent(-1 * target.FoodReserves.CurrentValue);
                     target.FoodReserves.UpdateAndReset();
                     GameLog.Client.GameData.DebugFormat("Tribbles.cs: target.FoodReserves after : {0}", target.FoodReserves);
                     
-
                     target.DeactivateFacility(ProductionCategory.Food);
-
-                    // Population
-                    //GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.AdjustCurrent(-population + 75);
-                    //GameContext.Current.Universe.Get<Colony>(targetColonyId).Population.UpdateAndReset();
-
-                    // Facilities
-                    //int removeFood = target.GetTotalFacilities(ProductionCategory.Food) - 6; // Food: remaining everything up to 6
-                    //if (removeFood < 7)
-                    //    removeFood = 0;
-                    //target.RemoveFacilities(ProductionCategory.Food, removeFood);
-
-                    //int removeIndustry = target.GetTotalFacilities(ProductionCategory.Industry) - 5; // Industry: remaining everything up to 5
-                    //if (removeIndustry < 6)
-                    //    removeIndustry = 0;
-                    //target.RemoveFacilities(ProductionCategory.Industry, removeIndustry);
-
-                    //int removeEnergy = target.GetTotalFacilities(ProductionCategory.Energy) - 2;  // Energy: remaining everything up to 2
-                    //if (removeEnergy < 3)
-                    //    removeEnergy = 0;
-                    //target.RemoveFacilities(ProductionCategory.Energy, removeEnergy);
-
-                    //int removeResearch = target.GetTotalFacilities(ProductionCategory.Research - 3);  // Research: remaining everything up to 3
-                    //if (removeResearch < 4)
-                    //    removeResearch = 0;
-                    //target.RemoveFacilities(ProductionCategory.Research, removeResearch);
-
-                    //int removeIntelligence = target.GetTotalFacilities(ProductionCategory.Intelligence - 3);  // Research: remaining everything up to 3
-                    //if (removeIntelligence < 4)
-                    //    removeIntelligence = 0;
-                    //target.RemoveFacilities(ProductionCategory.Intelligence, removeIntelligence); // Intelligence: remaining everything up to 0
-
-                    //// OrbitalBatteries
-                    //int removeOrbitalBatteries = target.OrbitalBatteries.Count;  // OrbitalBatteries: remaining everything up to 1
-                    //if (removeOrbitalBatteries < 2)
-                    //    removeOrbitalBatteries = 0;
-                    //target.RemoveOrbitalBatteries(removeOrbitalBatteries);
 
                     OnUnitTargeted(target);
 
@@ -216,10 +137,7 @@ namespace Supremacy.Scripting.Events
                                 "vfs:///Resources/SoundFX/ScriptedEvents/Tribbles.mp3",
                                 () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
 
-
-
                     GameContext.Current.Universe.UpdateSectors();
-
 
                     return;
                 }


### PR DESCRIPTION
This removes a *lot* of commented out code in the events, and hopefully fixes some of the problems in the linked bug (#11).

With all of the other population reducing events, it is set to take them down to a number. Earthquakes are different however in that it is set to decrease the population by 20. It does this without checking to see if there would be any population left.

This change makes it so that the population of the colony will not go underneath 20 if an earthquake occurs