### PR TITLE
Hail to engage

### DIFF
--- a/SupremacyCore/Combat/AutomatedCombatEngine.cs
+++ b/SupremacyCore/Combat/AutomatedCombatEngine.cs
@@ -94,14 +94,28 @@ namespace Supremacy.Combat
                 bool oppositionIsInFormation = oppositionShips.Any(os => os.Item1.Source.IsCombatant && (GetOrder(os.Item1.Source) == CombatOrder.Formation));
                 bool oppositionIsHailing = oppositionShips.Any(os => os.Item1.Source.IsCombatant && (GetOrder(os.Item1.Source) == CombatOrder.Hail));
                 bool oppositionIsRetreating = oppositionShips.Any(os => os.Item1.Source.IsCombatant && (GetOrder(os.Item1.Source) == CombatOrder.Retreat));
+                bool oppositionIsAttacking = oppositionShips.Any(os => os.Item1.Source.IsCombatant && ((GetOrder(os.Item1.Source) == CombatOrder.Engage) || (GetOrder(os.Item1.Source) == CombatOrder.Formation)) || (GetOrder(os.Item1.Source) == CombatOrder.Rush) || (GetOrder(os.Item1.Source) == CombatOrder.Transports));
 
                 var order = GetOrder(_combatShips[i].Item1.Source);
                 switch (order)
                 {
+                    case CombatOrder.Hail:
+                        if (_traceCombatEngine)
+                        {
+                            GameLog.Print("{0} {1} hailing...", _combatShips[i].Item1.Name, _combatShips[i].Item1.Source.ObjectID);
+                        }
+                        if (oppositionIsAttacking)
+                        {
+                            order = CombatOrder.Engage;
+                            GameLog.Print("{0} {1} {2} refiring...", _combatShips[i].Item1.Name, _combatShips[i].Item1.Source.ObjectID, order);
+                            goto case CombatOrder.Engage;
+                        }
+                        break;
                     case CombatOrder.Engage:
                     case CombatOrder.Rush:
                     case CombatOrder.Transports:
                     case CombatOrder.Formation:
+                        //refire:
 
                         var attackingShip = _combatShips[i].Item1;
                         var target = ChooseTarget(attackingShip);
@@ -236,12 +250,9 @@ namespace Supremacy.Combat
                         }
                         break;
 
-                    case CombatOrder.Hail:
-                        if (_traceCombatEngine)
-                        {
-                            GameLog.Print("{0} {1} hailing...", _combatShips[i].Item1.Name, _combatShips[i].Item1.Source.ObjectID);
-                        }
-                        break;
+
+                        
+                        
                 }
             }
 

--- a/SupremacyCore/Combat/AutomatedCombatEngine.cs
+++ b/SupremacyCore/Combat/AutomatedCombatEngine.cs
@@ -94,28 +94,15 @@ namespace Supremacy.Combat
                 bool oppositionIsInFormation = oppositionShips.Any(os => os.Item1.Source.IsCombatant && (GetOrder(os.Item1.Source) == CombatOrder.Formation));
                 bool oppositionIsHailing = oppositionShips.Any(os => os.Item1.Source.IsCombatant && (GetOrder(os.Item1.Source) == CombatOrder.Hail));
                 bool oppositionIsRetreating = oppositionShips.Any(os => os.Item1.Source.IsCombatant && (GetOrder(os.Item1.Source) == CombatOrder.Retreat));
-                bool oppositionIsAttacking = oppositionShips.Any(os => os.Item1.Source.IsCombatant && ((GetOrder(os.Item1.Source) == CombatOrder.Engage) || (GetOrder(os.Item1.Source) == CombatOrder.Formation)) || (GetOrder(os.Item1.Source) == CombatOrder.Rush) || (GetOrder(os.Item1.Source) == CombatOrder.Transports));
-
+               
                 var order = GetOrder(_combatShips[i].Item1.Source);
                 switch (order)
                 {
-                    case CombatOrder.Hail:
-                        if (_traceCombatEngine)
-                        {
-                            GameLog.Print("{0} {1} hailing...", _combatShips[i].Item1.Name, _combatShips[i].Item1.Source.ObjectID);
-                        }
-                        if (oppositionIsAttacking)
-                        {
-                            order = CombatOrder.Engage;
-                            GameLog.Print("{0} {1} {2} refiring...", _combatShips[i].Item1.Name, _combatShips[i].Item1.Source.ObjectID, order);
-                            goto case CombatOrder.Engage;
-                        }
-                        break;
+
                     case CombatOrder.Engage:
                     case CombatOrder.Rush:
                     case CombatOrder.Transports:
                     case CombatOrder.Formation:
-                        //refire:
 
                         var attackingShip = _combatShips[i].Item1;
                         var target = ChooseTarget(attackingShip);
@@ -243,16 +230,21 @@ namespace Supremacy.Combat
                         }
                         break;
 
+                    case CombatOrder.Hail:
+                        if (_traceCombatEngine)
+                        {
+                            GameLog.Print("{0} {1} hailing...", _combatShips[i].Item1.Name, _combatShips[i].Item1.Source.ObjectID);
+                        }
+
+                        break;
+
                     case CombatOrder.Standby:
                         if (_traceCombatEngine)
                         {
                             GameLog.Print("{0} {1} standing by...", _combatShips[i].Item1.Name, _combatShips[i].Item1.Source.ObjectID);
                         }
                         break;
-
-
-                        
-                        
+      
                 }
             }
 
@@ -304,10 +296,10 @@ namespace Supremacy.Combat
             }
 
             var attackerOrder = GetOrder(attacker.Source);
-            bool oppositionNotAttacking = ((GetOrder(attacker.Source) == CombatOrder.Hail) || (GetOrder(attacker.Source) == CombatOrder.Retreat) || (GetOrder(attacker.Source) == CombatOrder.Standby));
+            //bool oppositionNotAttacking = ((GetOrder(attacker.Source) == CombatOrder.Hail) || (GetOrder(attacker.Source) == CombatOrder.Retreat) || (GetOrder(attacker.Source) == CombatOrder.Standby));
             var attackerShipOwner = attacker.Owner;
 
-            if ((attackerOrder == CombatOrder.Hail && oppositionNotAttacking) || (attackerOrder == CombatOrder.LandTroops) || (attackerOrder == CombatOrder.Retreat) || (attackerOrder == CombatOrder.Standby))
+            if ((attackerOrder == CombatOrder.Hail) || (attackerOrder == CombatOrder.LandTroops) || (attackerOrder == CombatOrder.Retreat) || (attackerOrder == CombatOrder.Standby))
             {
                 throw new ArgumentException("Cannot chose a target for a ship that does not have orders that require a target");
             }

--- a/SupremacyCore/Combat/AutomatedCombatEngine.cs
+++ b/SupremacyCore/Combat/AutomatedCombatEngine.cs
@@ -304,9 +304,10 @@ namespace Supremacy.Combat
             }
 
             var attackerOrder = GetOrder(attacker.Source);
+            bool oppositionNotAttacking = ((GetOrder(attacker.Source) == CombatOrder.Hail) || (GetOrder(attacker.Source) == CombatOrder.Retreat) || (GetOrder(attacker.Source) == CombatOrder.Standby));
             var attackerShipOwner = attacker.Owner;
 
-            if ((attackerOrder == CombatOrder.Hail) || (attackerOrder == CombatOrder.LandTroops) || (attackerOrder == CombatOrder.Retreat) || (attackerOrder == CombatOrder.Standby))
+            if ((attackerOrder == CombatOrder.Hail && oppositionNotAttacking) || (attackerOrder == CombatOrder.LandTroops) || (attackerOrder == CombatOrder.Retreat) || (attackerOrder == CombatOrder.Standby))
             {
                 throw new ArgumentException("Cannot chose a target for a ship that does not have orders that require a target");
             }

--- a/SupremacyCore/Combat/CombatEngine.cs
+++ b/SupremacyCore/Combat/CombatEngine.cs
@@ -405,15 +405,15 @@ namespace Supremacy.Combat
                 return true;
             }
 
-            if (weaponRatio > 6) // if you rush and outgun the retreater they are less likely to get away
-            {
-                retreatChanceModifier = -30;
-                GameLog.Print("Weapon ratio was {0). -30 modifier", weaponRatio);
-            }
-            else if (weaponRatio > 3)
+            if (weaponRatio > 6) // if you outgun the retreater they are less likely to get away
             {
                 retreatChanceModifier = -20;
                 GameLog.Print("Weapon ratio was {0). -20 modifier", weaponRatio);
+            }
+            else if (weaponRatio > 3)
+            {
+                retreatChanceModifier = -15;
+                GameLog.Print("Weapon ratio was {0). -15 modifier", weaponRatio);
             }
             else if (weaponRatio > 1)
             {
@@ -426,9 +426,9 @@ namespace Supremacy.Combat
                 GameLog.Print("Weapon ratio was {0). 0 modifier", weaponRatio);
             }
 
-            if (oppositionIsRushing)
+            if (oppositionIsRushing) // if you rush the retreater they are less likely to get away
             {
-                retreatChanceModifier += -10;
+                retreatChanceModifier += -20;
                 if (_traceCombatEngine)
                 {
                     GameLog.Print("Opposition is rushing. -10 modifier (now {0})", retreatChanceModifier);


### PR DESCRIPTION
Found we do not need any special change of Hail order to Engage order.
Only some changes to the odds for retreat for Multi-player testing.