### PR TITLE
Medical ships (#90)

### DIFF
--- a/SupremacyCore/Diplomacy/Enums.cs
+++ b/SupremacyCore/Diplomacy/Enums.cs
@@ -130,7 +130,8 @@ namespace Supremacy.Diplomacy
         ViolatedStopSpying,
         EnemySharesQuadrant,
         DeclaredWar,
-        CapturedColony
+        CapturedColony,
+        HealedPopulation
     }
 
     [Flags]

--- a/SupremacyCore/Game/GameEngine.cs
+++ b/SupremacyCore/Game/GameEngine.cs
@@ -796,32 +796,8 @@ namespace Supremacy.Game
                             civManager.SitRepEntries.Add(new StarvationSitRepEntry(civ, colony));
                         }
                         else if (colony.Population.LastChange >= 0)
-                        {
-                            var growthRate = colony.System.GetGrowthRate(colony.Inhabitants);
-                            float growthRateMod = 1.0f;
-                            foreach (var building in colony.Buildings)
-                            {
-                                if (!building.IsActive)
-                                    continue;
-
-                                foreach (var buildingBonus in building.BuildingDesign.Bonuses)
-                                {
-                                    if (buildingBonus.BonusType == BonusType.PercentGrowthRate)
-                                    {
-                                        growthRateMod += (0.01f * buildingBonus.Amount);
-                                    }
-                                    if (buildingBonus.BonusType == BonusType.GrowthRate)
-                                    {
-                                        growthRate += (0.01f * buildingBonus.Amount);
-                                    }
-                                }
-                            }
-
-                            if (growthRateMod < 0.01f)
-                                growthRateMod = 0.01f;
-                            growthRate *= growthRateMod;
-
-                            popChange = (int)Math.Ceiling(growthRate * colony.Population.CurrentValue);
+                        {                         
+                            popChange = (int)Math.Ceiling(colony.System.GetGrowthRate(colony.Inhabitants) * colony.Population.CurrentValue);
                         }
 
                         int newPopulation = colony.Population.AdjustCurrent(popChange);

--- a/SupremacyCore/Universe/Colony.cs
+++ b/SupremacyCore/Universe/Colony.cs
@@ -296,7 +296,6 @@ namespace Supremacy.Universe
         {
             get
             {
-                decimal health = (decimal)_health.PercentFilled;
                 var baseGrowthRate = ((decimal)System.GetGrowthRate(Inhabitants) * (decimal)_health.PercentFilled) * 100;
                 var modifier = new ValueModifier<decimal>
                                {

--- a/SupremacyCore/Universe/Colony.cs
+++ b/SupremacyCore/Universe/Colony.cs
@@ -89,7 +89,7 @@ namespace Supremacy.Universe
         private int[] _facilityTypes;
         private int _orbitalBatteryDesign;
         private Meter _foodReserves;
-        private Percentage _health;
+        private Meter _health;
         private string _inhabitantId;
         private bool _isProductionAutomated;
         private Meter _morale;
@@ -120,7 +120,7 @@ namespace Supremacy.Universe
                 throw new ArgumentNullException("system");
             if (inhabitants == null)
                 throw new ArgumentNullException("inhabitants");
-            _health = 0;
+            _health = new Meter(80, 0, 100);
             _population.Maximum = system.GetMaxPopulation(inhabitants);
 
             _inhabitantId = inhabitants.Key;
@@ -492,7 +492,7 @@ namespace Supremacy.Universe
         /// Gets the population health level at this <see cref="Colony"/>.
         /// </summary>
         /// <value>The population health level.</value>
-        public Percentage Health
+        public Meter Health
         {
             get { return _health; }
         }
@@ -1844,7 +1844,7 @@ namespace Supremacy.Universe
             writer.WriteOptimized(_originalOwnerId);
             writer.WriteOptimized(_inhabitantId);
             writer.Write(_shipyardId);
-            writer.Write(_health);
+            _health.SerializeOwnedData(writer, context);
             _population.SerializeOwnedData(writer, context);
             _shieldStrength.SerializeOwnedData(writer, context);
             _morale.SerializeOwnedData(writer, context);
@@ -1943,7 +1943,7 @@ namespace Supremacy.Universe
             _originalOwnerId = reader.ReadOptimizedInt16();
             _inhabitantId = reader.ReadOptimizedString();
             _shipyardId = reader.ReadInt32();
-            _health = reader.ReadSingle();
+            _health.DeserializeOwnedData(reader, context);
             _population.DeserializeOwnedData(reader, context);
             _shieldStrength.DeserializeOwnedData(reader, context);
             _morale.DeserializeOwnedData(reader, context);

--- a/SupremacyUI/StarSystemPanel.cs
+++ b/SupremacyUI/StarSystemPanel.cs
@@ -308,24 +308,6 @@ namespace Supremacy.UI
             }
             else if (system != null)
             {
-                int maxPopulation;
-                Percentage growthRate;
-                Percentage populationHealth;
-
-                if (system.HasColony)
-                {
-                    maxPopulation = system.Colony.Population.Maximum;
-                    growthRate = system.Colony.GrowthRate;
-                    populationHealth = system.Colony.Health.PercentFilled;
-                }
-                else
-                {
-                    var targetRace = AppContext.LocalPlayerEmpire.Civilization.Race;
-                    growthRate = system.GetGrowthRate(targetRace);
-                    maxPopulation = system.GetMaxPopulation(targetRace);
-                    populationHealth = new Percentage(0);
-                }
-
                 switch (system.StarType)
                 {
                     case StarType.BlackHole:
@@ -403,39 +385,21 @@ namespace Supremacy.UI
                             name.Text = system.Name;
                         }
 
-                        morale.Text = string.Format("{0}: {1}",
-                            ResourceManager.GetString("MORALE"),
-                            system.HasColony ? system.Colony.Morale.CurrentValue : 0);
-
-
                         if (system.HasColony)
                         {
+                            morale.Text = string.Format("{0}: {1}",
+                                ResourceManager.GetString("MORALE"), system.Colony.Morale.CurrentValue);
                             population.Text = string.Format("{0}: {1:#,##0} of {2:#,##0}",
                                 ResourceManager.GetString("SYSTEM_POPULATION"),
-                                system.HasColony ? system.Colony.Population.CurrentValue : 0, maxPopulation);
-
-                        }
-                        else
-                        {
-                            population.Text = string.Format("{0}: {1:#,##0}",
-                                ResourceManager.GetString("SYSTEM_MAX_POPULATION"), maxPopulation);
-                        }
-
-                        growth.Text = string.Format("{0}: {1:0.#}%",
-                            ResourceManager.GetString("SYSTEM_GROWTH_RATE"), growthRate * 100);
-
-                        race.Text = system.HasColony
-                            ? string.Format("{0}: {1}",
-                                ResourceManager.GetString("SYSTEM_INHABITANTS"), system.Colony.Inhabitants.PluralName)
-                            : ResourceManager.GetString("SYSTEM_UNINHABITED");
-
-                        if (system.HasColony) {
+                                system.Colony.Population.CurrentValue, system.Colony.MaxPopulation);
+                            growth.Text = string.Format("{0}: {1:0.#}%",
+                                ResourceManager.GetString("SYSTEM_GROWTH_RATE"), system.Colony.GrowthRate * 100);
+                            race.Text = string.Format("{0}: {1}",
+                                ResourceManager.GetString("SYSTEM_INHABITANTS"), system.Colony.Inhabitants.PluralName);
+                            Percentage populationHealth = system.Colony.Health.PercentFilled;
                             health.Text = string.Format("{0}: {1:0.#}%",
                                 ResourceManager.GetString("SYSTEM_HEALTH"), populationHealth * 100);
-                        }
 
-                        if (system.HasColony)
-                        {
                             orbitals.SetBinding(
                                 TextBlock.TextProperty,
                                 new MultiBinding
@@ -459,17 +423,23 @@ namespace Supremacy.UI
                         }
                         else
                         {
+                            race.Text = ResourceManager.GetString("SYSTEM_UNINHABITED");
+                            population.Text = string.Format("{0}: {1:#,##0}",
+                                ResourceManager.GetString("SYSTEM_MAX_POPULATION"), system.GetMaxPopulation(AppContext.LocalPlayerEmpire.Civilization.Race));
+                            growth.Text = string.Format("{0}: {1:0.#}%",
+                                ResourceManager.GetString("SYSTEM_GROWTH_RATE"), system.GetGrowthRate(AppContext.LocalPlayerEmpire.Civilization.Race) * 100);
                             BindingOperations.ClearBinding(orbitals, TextBlock.TextProperty);
                         }
 
                         statsPanel.Children.Add(race);
-                        if (system.IsInhabited)
-                            statsPanel.Children.Add(morale);
                         statsPanel.Children.Add(population);
                         statsPanel.Children.Add(growth);
-                        if (system.HasColony)
+                        if (system.HasColony) {
                             statsPanel.Children.Add(health);
-                        statsPanel.Children.Add(orbitals);
+                            statsPanel.Children.Add(morale);
+                            statsPanel.Children.Add(orbitals);
+                        }
+
                         break;
                 }
             }

--- a/SupremacyUI/StarSystemPanel.cs
+++ b/SupremacyUI/StarSystemPanel.cs
@@ -276,7 +276,7 @@ namespace Supremacy.UI
             name.FontFamily = FontFamily;
             name.FontSize = (double)fontSize.ConvertFrom("14pt");
             name.Foreground = Brushes.LightBlue;
-            name.Margin = new Thickness(0, 0, 0, 14);
+            name.Margin = new Thickness(0, 0, 0, 2);
 
             details.FontFamily = FontFamily;
             details.FontSize = (double)fontSize.ConvertFrom("12pt");
@@ -288,7 +288,7 @@ namespace Supremacy.UI
             statsPanel.Orientation = Orientation.Vertical;
             statsPanel.Margin = new Thickness(0, 0, 14, 0);
             statsPanel.CanHorizontallyScroll = false;
-            if (!Double.IsNaN(ActualWidth))
+            if (!double.IsNaN(ActualWidth))
                 statsPanel.MaxWidth = ActualWidth;
             statsPanel.Children.Add(name);
 
@@ -310,17 +310,20 @@ namespace Supremacy.UI
             {
                 int maxPopulation;
                 Percentage growthRate;
+                Percentage populationHealth;
 
                 if (system.HasColony)
                 {
-                    growthRate = system.Colony.GrowthRate;
                     maxPopulation = system.Colony.Population.Maximum;
+                    growthRate = system.Colony.GrowthRate;
+                    populationHealth = system.Colony.Health.PercentFilled;
                 }
                 else
                 {
                     var targetRace = AppContext.LocalPlayerEmpire.Civilization.Race;
                     growthRate = system.GetGrowthRate(targetRace);
                     maxPopulation = system.GetMaxPopulation(targetRace);
+                    populationHealth = new Percentage(0);
                 }
 
                 switch (system.StarType)
@@ -331,7 +334,7 @@ namespace Supremacy.UI
                         statsPanel.Children.Add(details);
                         break;
                     case StarType.Wormhole:
-                        name.Text = String.Format(ResourceManager.GetString("WORMHOLE_NAME_FORMAT"),
+                        name.Text = string.Format(ResourceManager.GetString("WORMHOLE_NAME_FORMAT"),
                             system.Name);
                         details.Text = ResourceManager.GetString("STAR_TYPE_WORMHOLE_DESCRIPTION");
                         statsPanel.Children.Add(details);
@@ -364,24 +367,30 @@ namespace Supremacy.UI
                         var morale = new TextBlock();
                         var population = new TextBlock();
                         var growth = new TextBlock();
+                        var health = new TextBlock();
                         var race = new TextBlock();
                         var orbitals = new TextBlock();
 
                         morale.FontFamily = FontFamily;
                         population.FontFamily = FontFamily;
                         growth.FontFamily = FontFamily;
+                        health.FontFamily = FontFamily;
                         race.FontFamily = FontFamily;
                         orbitals.FontFamily = FontFamily;
 
                         morale.FontSize = population.FontSize
-                                        = growth.FontSize 
-                                        = race.FontSize 
-                                        = orbitals.FontSize 
+                                        = growth.FontSize
+                                        = health.FontSize
+                                        = race.FontSize
+                                        = orbitals.FontSize
                                         = (double)fontSize.ConvertFrom("11pt");
 
-                        morale.Foreground = population.Foreground 
-                                            = growth.Foreground 
-                                            = race.Foreground = orbitals.Foreground = Brushes.Beige;
+                        morale.Foreground = population.Foreground
+                                            = growth.Foreground
+                                            = health.Foreground
+                                            = race.Foreground
+                                            = orbitals.Foreground
+                                            = Brushes.Beige;
 
                         if (system.StarType == StarType.Nebula)
                         {
@@ -394,35 +403,36 @@ namespace Supremacy.UI
                             name.Text = system.Name;
                         }
 
-                        morale.Text = string.Format("{0}: {1}", ResourceManager.GetString("MORALE"),
+                        morale.Text = string.Format("{0}: {1}",
+                            ResourceManager.GetString("MORALE"),
                             system.HasColony ? system.Colony.Morale.CurrentValue : 0);
 
 
-                        if (system.HasColony) {
-                            population.Text = string.Format(
-                            "{0}: {1:#,##0} of {2:#,##0}",
-                            ResourceManager.GetString("SYSTEM_POPULATION"),
-                            system.HasColony ? system.Colony.Population.CurrentValue : 0,
-                            maxPopulation);
+                        if (system.HasColony)
+                        {
+                            population.Text = string.Format("{0}: {1:#,##0} of {2:#,##0}",
+                                ResourceManager.GetString("SYSTEM_POPULATION"),
+                                system.HasColony ? system.Colony.Population.CurrentValue : 0, maxPopulation);
 
                         }
                         else
                         {
                             population.Text = string.Format("{0}: {1:#,##0}",
-                                ResourceManager.GetString("SYSTEM_MAX_POPULATION"),
-                                maxPopulation);
+                                ResourceManager.GetString("SYSTEM_MAX_POPULATION"), maxPopulation);
                         }
 
-                        growth.Text = string.Format(
-                            "{0}: {1:0.#}%",
-                            ResourceManager.GetString("SYSTEM_GROWTH_RATE"),
-                            growthRate * 100);
+                        growth.Text = string.Format("{0}: {1:0.#}%",
+                            ResourceManager.GetString("SYSTEM_GROWTH_RATE"), growthRate * 100);
+
                         race.Text = system.HasColony
-                                        ? string.Format(
-                                              "{0}: {1}",
-                                              ResourceManager.GetString("SYSTEM_INHABITANTS"),
-                                              system.Colony.Inhabitants.PluralName)
-                                        : ResourceManager.GetString("SYSTEM_UNINHABITED");
+                            ? string.Format("{0}: {1}",
+                                ResourceManager.GetString("SYSTEM_INHABITANTS"), system.Colony.Inhabitants.PluralName)
+                            : ResourceManager.GetString("SYSTEM_UNINHABITED");
+
+                        if (system.HasColony) {
+                            health.Text = string.Format("{0}: {1:0.#}%",
+                                ResourceManager.GetString("SYSTEM_HEALTH"), populationHealth * 100);
+                        }
 
                         if (system.HasColony)
                         {
@@ -457,6 +467,8 @@ namespace Supremacy.UI
                             statsPanel.Children.Add(morale);
                         statsPanel.Children.Add(population);
                         statsPanel.Children.Add(growth);
+                        if (system.HasColony)
+                            statsPanel.Children.Add(health);
                         statsPanel.Children.Add(orbitals);
                         break;
                 }


### PR DESCRIPTION
Adds working medical orders for increasing a populations health. Population growth rate is affected by the health rate.

The more medical ships you have and the more powerful they are, the more the health increases each turn.

The diplomatic bit of the code currently has effect however, and I do not understand why