### PR TITLE
Use binary suffixes for all Borg ships

### DIFF
--- a/SupremacyCore/Orbitals/ShipDesign.cs
+++ b/SupremacyCore/Orbitals/ShipDesign.cs
@@ -440,8 +440,18 @@ namespace Supremacy.Orbitals
                 if (owner.ShipPrefix != null)
                     newShipName = owner.ShipPrefix + " ";
                 newShipName = newShipName + leastUsedName;
-                if (timesUsed > 0)
-                    newShipName = newShipName + " " + Utility.NameSuffixes.GetFromNumber(timesUsed);
+                if (ship.Owner.Key == "BORG")
+                {
+                    newShipName = newShipName + " " + ShipSuffixes.Binary(timesUsed + 1).PadLeft(4, '0');
+                }
+                else
+                {
+                    if (timesUsed > 0)
+                    {
+                        newShipName = newShipName + " " + ShipSuffixes.Alphabetical(timesUsed);
+                    }
+                }
+
                 ship.Name = newShipName;
                 
                 _possibleNames[leastUsedName] = timesUsed + 1;

--- a/SupremacyCore/SupremacyCore.csproj
+++ b/SupremacyCore/SupremacyCore.csproj
@@ -42,7 +42,7 @@
     <DocumentationFile>
     </DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <CodeContractsEnableRuntimeChecking>True</CodeContractsEnableRuntimeChecking>
     <CodeContractsRuntimeOnlyPublicSurface>False</CodeContractsRuntimeOnlyPublicSurface>
     <CodeContractsRuntimeThrowOnFailure>True</CodeContractsRuntimeThrowOnFailure>
@@ -260,7 +260,7 @@
     <Compile Include="Utility\EnumUtilities.cs" />
     <Compile Include="Utility\GameScheduler.cs" />
     <Compile Include="Utility\GCHelper.cs" />
-    <Compile Include="Utility\NameSuffixes.cs" />
+    <Compile Include="Utility\ShipSuffixes.cs" />
     <Compile Include="Utility\ObjectDumper.cs" />
     <Compile Include="Utility\TryConvert.cs" />
     <Compile Include="Utility\XmlWriterEx.cs" />

--- a/SupremacyCore/Utility/ShipSuffixes.cs
+++ b/SupremacyCore/Utility/ShipSuffixes.cs
@@ -1,8 +1,10 @@
-﻿namespace Supremacy.Utility
+﻿using System;
+
+namespace Supremacy.Utility
 {
-    class NameSuffixes
+    class ShipSuffixes
     {
-        public static string GetFromNumber(int number)
+        public static string Alphabetical(int number)
         {
             const string letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -14,6 +16,11 @@
             suffix += letters[number % letters.Length];
 
             return suffix;
+        }
+
+        public static string Binary(int number)
+        {
+            return Convert.ToString(number, 2);
         }
     }
 }


### PR DESCRIPTION
As well as fixing a bug when making the release, the pull request implements binary suffixes for ships (currently only Borg). This saves having to do it in the data files

The data files on Dropbox have been modified accordingly. I have also fixed some problems with the Borg ships in the data files (Tactical Cubes and Diamonds were reversed, and the key for I think it was the Construction ships made obsolete was incorrect)