### PR TITLE
Combat factors

### DIFF
--- a/SupremacyClient/CombatWindow.xaml.cs
+++ b/SupremacyClient/CombatWindow.xaml.cs
@@ -32,7 +32,7 @@ namespace Supremacy.Client
     /// <summary>
     /// Interaction logic for CombatWindow.xaml
     /// </summary>
-
+    
     public partial class CombatWindow
     {
         private CombatUpdate _update;
@@ -85,6 +85,16 @@ namespace Supremacy.Client
 
             if (update.IsCombatOver)
             {
+                if (update.RoundNumber == 6) // add fitting text, for when the battle is over Roundnumber must be 1 more then in the forced reatreat/combat ending.
+                {
+                    HeaderText.Text = ResourceManager.GetString("COMBAT_HEADER") + ": "
+                        + String.Format(ResourceManager.GetString("COMBAT_STANDOFF"));
+                    SubHeaderText.Text = String.Format(
+                        ResourceManager.GetString("COMBAT_TEXT_LONG_BATTLE_OVER"),
+                        _update.Sector.Name);
+                } 
+
+
                 if (_update.IsStandoff)
                 {
                     HeaderText.Text = ResourceManager.GetString("COMBAT_HEADER") + ": "

--- a/SupremacyClientComponents/Views/SystemAssaultScreen/SystemAssaultScreenViewModel.cs
+++ b/SupremacyClientComponents/Views/SystemAssaultScreen/SystemAssaultScreenViewModel.cs
@@ -1314,10 +1314,10 @@ namespace Supremacy.Client.Views
         private TimeSpan _explosionIntervalBalanced = TimeSpan.FromSeconds(0.5);
         private TimeSpan _explosionIntervalMaxDamage = TimeSpan.FromSeconds(0.25);
         private TimeSpan _explosionIntervalUnloadAllOrdinance = TimeSpan.FromSeconds(0.05);
-        private TimeSpan _attackOrbitalDefensesReplayDuration = TimeSpan.FromSeconds(11);
-        private TimeSpan _bombardmentReplayDuration = TimeSpan.FromSeconds(8);
-        private TimeSpan _unloadAllOrdinanceReplayDuration = TimeSpan.FromSeconds(11);
-        private TimeSpan _landTroopsReplayDuration = TimeSpan.FromSeconds(16);
+        private TimeSpan _attackOrbitalDefensesReplayDuration = TimeSpan.FromSeconds(3); // Don´t want to wait 11 secounds... for animation/sound
+        private TimeSpan _bombardmentReplayDuration = TimeSpan.FromSeconds(2); // 2 is better then 8
+        private TimeSpan _unloadAllOrdinanceReplayDuration = TimeSpan.FromSeconds(3); //AHA! Don´t want to wait 11 secounds... for animation/sound
+        private TimeSpan _landTroopsReplayDuration = TimeSpan.FromSeconds(2); // from 16 to2
 
         public TimeSpan ExplosionIntervalMaxPrecision
         {

--- a/SupremacyClientComponents/Views/SystemAssaultScreen/SystemAssaultScreenViewModelOld.cs
+++ b/SupremacyClientComponents/Views/SystemAssaultScreen/SystemAssaultScreenViewModelOld.cs
@@ -1,0 +1,1505 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Threading;
+using System.Windows.Data;
+using System.Windows.Input;
+
+using Microsoft.Practices.Composite.Presentation.Events;
+using Microsoft.Practices.Composite.Regions;
+
+using Supremacy.Annotations;
+using Supremacy.Buildings;
+using Supremacy.Client.Commands;
+using Supremacy.Client.Dialogs;
+using Supremacy.Client.Events;
+using Supremacy.Client.Input;
+using Supremacy.Combat;
+using Supremacy.Economy;
+using Supremacy.Entities;
+using Supremacy.Game;
+using Supremacy.Orbitals;
+using Supremacy.Resources;
+using Supremacy.Tech;
+using Supremacy.Types;
+using Supremacy.Universe;
+using Supremacy.Utility;
+
+using System.Linq;
+
+using Supremacy.Collections;
+using Supremacy.VFS;
+using Supremacy.Xaml;
+using Supremacy.Client.Audio;
+
+using NavigationCommands = Supremacy.Client.Commands.NavigationCommands;
+using Scheduler = System.Concurrency.Scheduler;
+using Microsoft.Practices.ServiceLocation;
+using Supremacy.Client.Context;
+
+namespace Supremacy.Client.Views
+{
+    [TypeConverter(typeof(StateConverter<SystemAssaultScreenState>))]
+    public sealed class SystemAssaultScreenState : State
+    {
+        public static readonly SystemAssaultScreenState AwaitingPlayerOrders = new SystemAssaultScreenState(0);
+        public static readonly SystemAssaultScreenState WaitingForUpdate = new SystemAssaultScreenState(1);
+        public static readonly SystemAssaultScreenState ReplayingResults = new SystemAssaultScreenState(2);
+        public static readonly SystemAssaultScreenState Finished = new SystemAssaultScreenState(3);
+
+        private SystemAssaultScreenState(int value)
+            : base(value) { }
+    }
+
+    public class SystemAssaultScreenViewModel : ViewModelBase<ISystemAssaultScreenView, SystemAssaultScreenViewModel>
+    {
+        private static SystemAssaultScreenViewModel _designInstance;
+
+        public static SystemAssaultScreenViewModel DesignInstance
+        {
+            get
+            {
+                if (_designInstance == null)
+                    _designInstance = new SystemAssaultScreenViewModel(DesignTimeAppContext.Instance, null,
+                        ServiceLocator.Current.GetInstance<ISoundPlayer>());
+                return _designInstance;
+            }
+        }
+
+        private readonly StateManager<SystemAssaultScreenState> _stateManager;
+
+        private readonly DelegateCommand<InvasionUnit> _standbyOrderCommand;
+        private readonly DelegateCommand<InvasionUnit> _attackOrderCommand;
+        private readonly DelegateCommand<InvasionUnit> _landTroopsOrderCommand;
+        private readonly DelegateCommand<ICheckableCommandParameter> _setActionCommand;
+        private readonly DelegateCommand<ICheckableCommandParameter> _setTargetingStrategyCommand;
+        private readonly DelegateCommand<object> _commitOrdersCommand;
+        private readonly DelegateCommand<object> _doneCommand;
+
+        private readonly Meter _defenderPopulation;
+        private readonly Meter _colonyShieldStrength;
+        private readonly Meter _defenderCombatStrength;
+
+        private readonly ObservableCollection<AssaultUnitViewModel> _invadingUnits;
+        private readonly ObservableCollection<AssaultUnitViewModel> _troopTransports;
+        private readonly ObservableCollection<AssaultUnitViewModel> _destroyedInvadingUnits;
+        private readonly ObservableCollection<AssaultUnitViewModel> _defendingUnits;
+        private readonly ObservableCollection<AssaultUnitViewModel> _destroyedDefendingUnits;
+
+        private ISoundPlayer _soundPlayer = null;
+        private InvasionArena _currentUpdate;
+
+        public SystemAssaultScreenViewModel([NotNull] IAppContext appContext, IRegionManager regionManager, [NotNull] ISoundPlayer soundPlayer)
+            : base(appContext, regionManager)
+        {
+            _standbyOrderCommand = new DelegateCommand<InvasionUnit>(ExecuteStandbyOrderCommand, CanExecuteStandbyOrderCommand);
+            _attackOrderCommand = new DelegateCommand<InvasionUnit>(ExecuteAttackOrderCommand, CanExecuteAttackOrderCommand);
+            _landTroopsOrderCommand = new DelegateCommand<InvasionUnit>(ExecuteLandTroopsOrderCommand, CanExecuteLandTroopsOrderCommand);
+            _commitOrdersCommand = new DelegateCommand<object>(ExecuteCommitOrdersCommand, CanExecuteCommitOrdersCommand);
+            _setActionCommand = new DelegateCommand<ICheckableCommandParameter>(ExecuteSetActionCommand, CanExecuteSetActionCommand);
+            _setTargetingStrategyCommand = new DelegateCommand<ICheckableCommandParameter>(ExecuteSetTargetingStrategyCommand, CanExecuteSetTargetingStrategyCommand);
+            _doneCommand = new DelegateCommand<object>(ExecuteDoneCommand, CanExecuteDoneCommand);
+
+            _defenderPopulation = new Meter(0, 0, 0);
+            _defenderCombatStrength = new Meter(0, 0, 0);
+            _colonyShieldStrength = new Meter(0, 0, 0);
+
+            _defenderCombatStrength.CurrentValueChanged += (o, eventArgs) => OnSelectedTransportsNetCombatStrengthChanged();
+
+            _invadingUnits = new ObservableCollection<AssaultUnitViewModel>();
+            _destroyedInvadingUnits = new ObservableCollection<AssaultUnitViewModel>();
+            _defendingUnits = new ObservableCollection<AssaultUnitViewModel>();
+            _destroyedDefendingUnits = new ObservableCollection<AssaultUnitViewModel>();
+            _troopTransports = new ObservableCollection<AssaultUnitViewModel>();
+
+            CollectionViewSource.GetDefaultView(_invadingUnits).GroupDescriptions.Add(new PropertyGroupDescription("Category"));
+            CollectionViewSource.GetDefaultView(_destroyedInvadingUnits).GroupDescriptions.Add(new PropertyGroupDescription("Category"));
+            CollectionViewSource.GetDefaultView(_defendingUnits).GroupDescriptions.Add(new PropertyGroupDescription("Category"));
+            CollectionViewSource.GetDefaultView(_destroyedDefendingUnits).GroupDescriptions.Add(new PropertyGroupDescription("Category"));
+
+            _stateManager = new StateManager<SystemAssaultScreenState>(
+                SystemAssaultScreenState.Finished,
+                new StateTransition<SystemAssaultScreenState>(
+                    SystemAssaultScreenState.AwaitingPlayerOrders,
+                    SystemAssaultScreenState.WaitingForUpdate,
+                    StateChangeDisposition.MustHappen),
+                new StateTransition<SystemAssaultScreenState>(
+                    SystemAssaultScreenState.WaitingForUpdate,
+                    SystemAssaultScreenState.ReplayingResults,
+                    StateChangeDisposition.MustHappen),
+                new StateTransition<SystemAssaultScreenState>(
+                    SystemAssaultScreenState.ReplayingResults,
+                    SystemAssaultScreenState.AwaitingPlayerOrders,
+                    StateChangeDisposition.MustHappen),
+                new StateTransition<SystemAssaultScreenState>(
+                    SystemAssaultScreenState.ReplayingResults,
+                    SystemAssaultScreenState.Finished,
+                    StateChangeDisposition.MustHappen),
+                new StateTransition<SystemAssaultScreenState>(
+                    SystemAssaultScreenState.Finished,
+                    SystemAssaultScreenState.AwaitingPlayerOrders,
+                    StateChangeDisposition.MustHappen),
+                new StateTransition<SystemAssaultScreenState>(
+                    SystemAssaultScreenState.AwaitingPlayerOrders,
+                    SystemAssaultScreenState.Finished,
+                    StateChangeDisposition.Optional),
+                new StateTransition<SystemAssaultScreenState>(
+                    SystemAssaultScreenState.WaitingForUpdate,
+                    SystemAssaultScreenState.Finished,
+                    StateChangeDisposition.Optional));
+
+            _stateManager.StateChanged += (sender, args) => OnStateChanged();
+
+            if (soundPlayer == null)
+                throw new ArgumentNullException("soundPlayer");
+            _soundPlayer = soundPlayer;
+
+            RoundNumber = 1;
+        }
+
+        public override string ViewName
+        {
+            get { return StandardGameScreens.SystemAssaultScreen; }
+        }
+
+        #region Commands
+
+        public ICommand SetActionCommand
+        {
+            get { return _setActionCommand; }
+        }
+
+        public ICommand SetTargetingStrategyCommand
+        {
+            get { return _setTargetingStrategyCommand; }
+        }
+
+        public ICommand CommitOrdersCommand
+        {
+            get { return _commitOrdersCommand; }
+        }
+
+        public ICommand StandbyOrderCommand
+        {
+            get { return _standbyOrderCommand; }
+        }
+
+        public ICommand AttackOrderCommand
+        {
+            get { return _attackOrderCommand; }
+        }
+
+        public ICommand LandTroopsOrderCommand
+        {
+            get { return _landTroopsOrderCommand; }
+        }
+
+        public ICommand DoneCommand
+        {
+            get { return _doneCommand; }
+        }
+
+        public Meter DefenderPopulation
+        {
+            get { return _defenderPopulation; }
+        }
+
+        public Meter DefenderCombatStrength
+        {
+            get { return _defenderCombatStrength; }
+        }
+
+        public Meter ColonyShieldStrength
+        {
+            get { return _colonyShieldStrength; }
+        }
+
+        #endregion
+
+        public IEnumerable<AssaultUnitViewModel> InvadingUnits
+        {
+            get { return _invadingUnits; }
+        }
+
+        public IEnumerable<AssaultUnitViewModel> TroopTransports
+        {
+            get { return _troopTransports; }
+        }
+
+        public IEnumerable<AssaultUnitViewModel> DefendingUnits
+        {
+            get { return _defendingUnits; }
+        }
+
+        public IEnumerable<AssaultUnitViewModel> DestroyedInvadingUnits
+        {
+            get { return _destroyedInvadingUnits; }
+        }
+
+        public IEnumerable<AssaultUnitViewModel> DestroyedDefendingUnits
+        {
+            get { return _destroyedDefendingUnits; }
+        }
+
+        #region Invader Property
+
+        [field: NonSerialized]
+        public event EventHandler InvaderChanged;
+
+        private Civilization _invader;
+
+        public Civilization Invader
+        {
+            get { return _invader; }
+            set
+            {
+                if (Equals(value, _invader))
+                    return;
+
+                _invader = value;
+
+                OnInvaderChanged();
+            }
+        }
+
+        protected virtual void OnInvaderChanged()
+        {
+            InvaderChanged.Raise(this);
+            OnPropertyChanged("Invader");
+        }
+
+        #endregion
+
+        #region Defender Property
+
+        [field: NonSerialized]
+        public event EventHandler DefenderChanged;
+
+        private Civilization _defender;
+
+        public Civilization Defender
+        {
+            get { return _defender; }
+            set
+            {
+                if (Equals(value, _defender))
+                    return;
+
+                _defender = value;
+
+                OnDefenderChanged();
+            }
+        }
+
+        protected virtual void OnDefenderChanged()
+        {
+            DefenderChanged.Raise(this);
+            OnPropertyChanged("Defender");
+        }
+
+        #endregion
+
+        #region InvasionStatus Property
+
+        [field: NonSerialized]
+        public event EventHandler InvasionStatusChanged;
+
+        public InvasionStatus InvasionStatus
+        {
+            get { return _currentUpdate == null ? InvasionStatus.InProgress : _currentUpdate.Status; }
+        }
+
+        protected virtual void OnInvasionStatusChanged()
+        {
+            InvasionStatusChanged.Raise(this);
+            OnPropertyChanged("InvasionStatus");
+        }
+
+        #endregion
+
+        #region StarSystem Property
+
+        [field: NonSerialized]
+        public event EventHandler StarSystemChanged;
+
+        private StarSystem _starSystem;
+
+        public StarSystem StarSystem
+        {
+            get { return _starSystem; }
+            set
+            {
+                if (Equals(value, _starSystem))
+                    return;
+
+                _starSystem = value;
+
+                OnStarSystemChanged();
+            }
+        }
+
+        protected virtual void OnStarSystemChanged()
+        {
+            StarSystemChanged.Raise(this);
+            OnPropertyChanged("StarSystem");
+        }
+
+        #endregion
+
+        #region RoundNumber Property
+
+        [field: NonSerialized]
+        public event EventHandler RoundNumberChanged;
+
+        private int _roundNumber;
+
+        public int RoundNumber
+        {
+            get { return _roundNumber; }
+            private set
+            {
+                if (Equals(value, _roundNumber))
+                    return;
+
+                _roundNumber = value;
+
+                OnRoundNumberChanged();
+            }
+        }
+
+        protected virtual void OnRoundNumberChanged()
+        {
+            RoundNumberChanged.Raise(this);
+            OnPropertyChanged("RoundNumber");
+        }
+
+        #endregion
+
+        #region SelectedAction Property
+
+        [field: NonSerialized]
+        public event EventHandler SelectedActionChanged;
+
+        private InvasionAction? _selectedAction;
+
+        public InvasionAction? SelectedAction
+        {
+            get { return _selectedAction; }
+            set
+            {
+                //if (Equals(value, _selectedAction))
+                //    return;
+
+                _selectedAction = value;
+
+                OnSelectedActionChanged();
+            }
+        }
+
+        protected virtual void OnSelectedActionChanged()
+        {
+            SelectedActionChanged.Raise(this);
+            OnPropertyChanged("SelectedAction");
+        }
+
+        #endregion
+
+        #region SelectedTargetingStrategy Property
+
+        [field: NonSerialized]
+        public event EventHandler SelectedTargetingStrategyChanged;
+
+        private InvasionTargetingStrategy _selectedTargetingStrategy = InvasionTargetingStrategy.Balanced;
+
+        public InvasionTargetingStrategy SelectedTargetingStrategy
+        {
+            get { return _selectedTargetingStrategy; }
+            set
+            {
+                if (Equals(value, _selectedTargetingStrategy))
+                    return;
+
+                if (EnumHelper.IsDefined(value))
+                    _selectedTargetingStrategy = value;
+                else
+                    _selectedTargetingStrategy = InvasionTargetingStrategy.Balanced;
+
+                OnSelectedTargetingStrategyChanged();
+            }
+        }
+
+        protected virtual void OnSelectedTargetingStrategyChanged()
+        {
+            SelectedTargetingStrategyChanged.Raise(this);
+            OnPropertyChanged("SelectedTargetingStrategy");
+        }
+
+        #endregion
+
+        #region State Property
+
+        [field: NonSerialized]
+        public event EventHandler StateChanged;
+
+        public SystemAssaultScreenState State
+        {
+            get { return _stateManager.CurrentState; }
+        }
+
+        protected virtual void OnStateChanged()
+        {
+            StateChanged.Raise(this);
+            OnPropertyChanged("State");
+            OnExplosionIntervalChanged();
+            InvalidateCommands();
+        }
+
+        #endregion
+
+        #region ExplosionInterval Property
+
+        [field: NonSerialized]
+        public event EventHandler ExplosionIntervalChanged;
+
+        private TimeSpan? _explosionInterval;
+
+        public TimeSpan? ExplosionInterval
+        {
+            get { return _explosionInterval; }
+            set
+            {
+                if (Equals(value, _explosionInterval))
+                    return;
+
+                _explosionInterval = value;
+
+                OnExplosionIntervalChanged();
+            }
+        }
+
+        protected virtual void OnExplosionIntervalChanged()
+        {
+            ExplosionIntervalChanged.Raise(this);
+            OnPropertyChanged("ExplosionInterval");
+        }
+
+        #endregion
+
+        #region PrimaryPlanet Property
+
+        [field: NonSerialized]
+        public event EventHandler PrimaryPlanetChanged;
+
+        private Planet _primaryPlanet;
+
+        public Planet PrimaryPlanet
+        {
+            get { return _primaryPlanet; }
+            set
+            {
+                if (Equals(value, _primaryPlanet))
+                    return;
+
+                _primaryPlanet = value;
+
+                OnPrimaryPlanetChanged();
+            }
+        }
+
+        protected virtual void OnPrimaryPlanetChanged()
+        {
+            PrimaryPlanetChanged.Raise(this);
+            OnPropertyChanged("PrimaryPlanet");
+        }
+
+        #endregion
+
+        #region SelectedTransportsCombatStrength Property
+
+        [field: NonSerialized]
+        public event EventHandler SelectedTransportsCombatStrengthChanged;
+
+        private int _selectedTransportsCombatStrength;
+
+        public int SelectedTransportsCombatStrength
+        {
+            get { return _selectedTransportsCombatStrength; }
+            private set
+            {
+                if (Equals(value, _selectedTransportsCombatStrength))
+                    return;
+
+                _selectedTransportsCombatStrength = value;
+
+                OnSelectedTransportsCombatStrengthChanged();
+                OnGroundCombatOddsChanged();
+            }
+        }
+
+        protected virtual void OnSelectedTransportsCombatStrengthChanged()
+        {
+            SelectedTransportsCombatStrengthChanged.Raise(this);
+            OnPropertyChanged("SelectedTransportsCombatStrength");
+            OnSelectedTransportsNetCombatStrengthChanged();
+        }
+
+        protected void UpdateSelectedTransportsCombatStrength()
+        {
+            SelectedTransportsCombatStrength = TroopTransports
+                .Where(o => o.IsSelected && !o.IsDestroyed)
+                .Select(o => o.Unit.Source)
+                .OfType<Ship>()
+                .Select(o => o.ShipDesign.WorkCapacity)
+                .Sum(pop => CombatHelper.ComputeGroundCombatStrength(Invader, StarSystem.Location, pop));
+        }
+
+        #endregion
+
+        #region SelectedTransportsNetCombatStrength Property
+
+        [field: NonSerialized]
+        public event EventHandler SelectedTransportsNetCombatStrengthChanged;
+
+
+
+        public int SelectedTransportsNetCombatStrength
+        {
+            get { return SelectedTransportsCombatStrength - DefenderCombatStrength.CurrentValue; }
+        }
+
+        protected virtual void OnSelectedTransportsNetCombatStrengthChanged()
+        {
+            SelectedTransportsNetCombatStrengthChanged.Raise(this);
+            GroundCombatOddsChanged.Raise(this);
+            OnPropertyChanged("SelectedTransportsNetCombatStrength");
+        }
+
+        #endregion
+
+
+        #region GroundCombatOdds Property
+
+        [field: NonSerialized]
+        public event EventHandler GroundCombatOddsChanged;
+
+
+
+        public int GroundCombatOdds
+        {
+            get
+            {
+                int GroundCombatOddsValue = 100; 
+                try
+                {
+                    int attack = SelectedTransportsCombatStrength ;   // minus ? - 5
+                    int defend = _defenderCombatStrength.CurrentValue ;  // plus + 5
+
+                    GroundCombatOddsValue = 100 + attack - defend;
+
+                    GameLog.Client.General.DebugFormat("SelectedTransportsCombatStrength = {0}, _defenderCombatStrength.CurrentValue = {1}, GroundCombatOdds = {2}",
+                        SelectedTransportsCombatStrength, _defenderCombatStrength.CurrentValue, GroundCombatOddsValue);
+
+                    // 
+                }
+                catch
+                {
+                    //GroundCombatOdds = 99;
+                }
+
+                //GroundCombatOddsValue = GroundCombatOddsValue / 100;
+
+                if (GroundCombatOddsValue > 100)
+                    GroundCombatOddsValue = 100;
+
+                if (GroundCombatOddsValue < 0)
+                    GroundCombatOddsValue = 0;
+
+                //GroundCombatOddsValue = 99;
+                return GroundCombatOddsValue;
+            }
+        }
+
+        protected virtual void OnGroundCombatOddsChanged()
+        {
+            GroundCombatOddsChanged.Raise(this);
+            OnPropertyChanged("SelectedTransportsNetCombatStrength");
+            OnPropertyChanged("GroundCombatOdds");
+        }
+
+        #endregion
+
+        #region Command Handlers
+
+        private bool CanExecuteSetActionCommand(ICheckableCommandParameter p)
+        {
+            if (p == null || State != SystemAssaultScreenState.AwaitingPlayerOrders)
+                return false;
+
+            var action = p.InnerParameter as InvasionAction?;
+            if (action == null)
+                return true;
+
+            var canExecute = true;
+
+            switch (action.Value)
+            {
+                case InvasionAction.AttackOrbitalDefenses:
+                    canExecute = _currentUpdate.HasOrbitalDefenses;
+                    break;
+                case InvasionAction.BombardPlanet:
+                case InvasionAction.UnloadAllOrdinance:
+                    canExecute = _currentUpdate.HasAttackingUnits;
+                    break;
+                case InvasionAction.LandTroops:
+                    canExecute = _currentUpdate.CanLandTroops;
+                    break;
+            }
+
+            p.IsChecked = (SelectedAction == action) && canExecute;
+
+            return canExecute;
+        }
+
+        private void ExecuteSetActionCommand(ICheckableCommandParameter p)
+        {
+            if (!CanExecuteSetActionCommand(p))
+                return;
+
+            SelectedAction = (InvasionAction?)p.InnerParameter;
+            InvalidateCommands();
+        }
+
+        private bool CanExecuteSetTargetingStrategyCommand(ICheckableCommandParameter p)
+        {
+            if (p == null || State != SystemAssaultScreenState.AwaitingPlayerOrders)
+                return false;
+
+            var targetingStrategy = p.InnerParameter as InvasionTargetingStrategy?;
+            if (targetingStrategy == null)
+                return false;
+
+            p.IsChecked = (SelectedTargetingStrategy == targetingStrategy);
+
+            return SelectedAction.HasValue &&
+                   SelectedAction == InvasionAction.BombardPlanet;
+        }
+
+        private void ExecuteSetTargetingStrategyCommand(ICheckableCommandParameter p)
+        {
+            if (!CanExecuteSetTargetingStrategyCommand(p))
+                return;
+
+            SelectedTargetingStrategy = (InvasionTargetingStrategy)p.InnerParameter;
+            InvalidateCommands();
+        }
+
+        private bool CanExecuteCommitOrdersCommand(object _)
+        {
+            if (State != SystemAssaultScreenState.AwaitingPlayerOrders || !SelectedAction.HasValue)
+                return false;
+
+            if (SelectedAction == InvasionAction.LandTroops && !TroopTransports.Any(o => o.IsSelected))
+                return false;
+
+            return true;
+        }
+
+        private bool CanExecuteLandTroopsOrderCommand(InvasionUnit arg)
+        {
+            return false;
+        }
+
+        private bool CanExecuteAttackOrderCommand(InvasionUnit arg)
+        {
+            return false;
+        }
+
+        private bool CanExecuteStandbyOrderCommand(InvasionUnit arg)
+        {
+            return false;
+        }
+
+        private void ExecuteCommitOrdersCommand(object _)
+        {
+            if (!CanExecuteCommitOrdersCommand(null))
+                return;
+
+            // ReSharper disable PossibleInvalidOperationException
+            ClientCommands.SendInvasionOrders.Execute(
+                new InvasionOrders(
+                    _currentUpdate.InvasionID,
+                    SelectedAction.Value,
+                    SelectedTargetingStrategy,
+                    TroopTransports.Where(o => o.IsSelected).Select(o => o.Unit)));
+            // ReSharper restore PossibleInvalidOperationException
+
+            _stateManager.TryChange(SystemAssaultScreenState.WaitingForUpdate);
+        }
+
+        private void ExecuteLandTroopsOrderCommand(InvasionUnit unit) { }
+
+        private void ExecuteAttackOrderCommand(InvasionUnit unit) { }
+
+        private void ExecuteStandbyOrderCommand(InvasionUnit unit) { }
+
+        private void ExecuteDoneCommand(object _)
+        {
+            ClientCommands.EndInvasion.Execute(null);
+            NavigationCommands.ActivateScreen.Execute(StandardGameScreens.GalaxyScreen);
+            Terminate();
+        }
+
+        private bool CanExecuteDoneCommand(object _)
+        {
+            return State == SystemAssaultScreenState.Finished;
+        }
+
+        #endregion
+
+        protected override void RunOverride()
+        {
+            var dialog = View as IDialog;
+            if (dialog != null && !dialog.IsOpen)
+                dialog.Show();
+        }
+
+        protected override void RegisterCommandAndEventHandlers()
+        {
+            ClientEvents.InvasionUpdateReceived.Subscribe(OnInvasionUpdateReceived, ThreadOption.UIThread);
+        }
+
+        protected override void UnregisterCommandAndEventHandlers()
+        {
+            ClientEvents.InvasionUpdateReceived.Unsubscribe(OnInvasionUpdateReceived);
+        }
+
+        protected override void InvalidateCommands()
+        {
+            base.InvalidateCommands();
+
+            _standbyOrderCommand.RaiseCanExecuteChanged();
+            _attackOrderCommand.RaiseCanExecuteChanged();
+            _landTroopsOrderCommand.RaiseCanExecuteChanged();
+            _commitOrdersCommand.RaiseCanExecuteChanged();
+            _setActionCommand.RaiseCanExecuteChanged();
+            _setTargetingStrategyCommand.RaiseCanExecuteChanged();
+            _doneCommand.RaiseCanExecuteChanged();
+        }
+
+        protected override void TerminateOverride()
+        {
+            OnClose();
+
+            if (State != SystemAssaultScreenState.Finished)
+                _stateManager.TryChange(SystemAssaultScreenState.Finished);
+        }
+
+        private void OnClose()
+        {
+            var dialog = View as IDialog;
+            if (dialog != null)
+                dialog.Close();
+
+            _currentUpdate = null;
+            _invadingUnits.Clear();
+            _troopTransports.ForEach(o => o.IsSelectedChanged -= OnTroopTransportIsSelectedChanged);
+            _troopTransports.Clear();
+            _destroyedInvadingUnits.Clear();
+            _defendingUnits.Clear();
+            _destroyedDefendingUnits.Clear();
+
+            StarSystem = null;
+            PrimaryPlanet = null;
+
+            RoundNumber = 1;
+        }
+
+        private void OnTroopTransportIsSelectedChanged(object sender, EventArgs eventArgs)
+        {
+            UpdateSelectedTransportsCombatStrength();
+        }
+
+        private void OnInvasionUpdateReceived(ClientDataEventArgs<InvasionArena> e)
+        {
+            var newUpdate = e.Value;
+
+            if (_currentUpdate != null &&
+                _currentUpdate.InvasionID != newUpdate.InvasionID)
+            {
+                if (_currentUpdate.IsFinished)
+                    _currentUpdate = null;
+                else
+                    throw new InvalidOperationException("Combat update received while another combat was in progress.");
+            }
+
+            ProcessUpdate(newUpdate);
+
+            //ServiceLocator.Current.GetInstance<INavigationService>().ActivateScreen(this.ViewName);
+        }
+
+        private void PlaybackResults([NotNull] InvasionArena update)
+        {
+            var settings = AssaultScreenSettings.Instance;
+
+            _stateManager.TryChange(SystemAssaultScreenState.ReplayingResults);
+            
+            if (SelectedAction == InvasionAction.UnloadAllOrdinance)
+            {
+                ExplosionInterval = settings.ExplosionIntervalUnloadAllOrdinance;
+            }
+            else if (SelectedAction == InvasionAction.BombardPlanet)
+            {
+                switch (SelectedTargetingStrategy)
+                {
+                    case InvasionTargetingStrategy.MaximumPrecision:
+                        ExplosionInterval = settings.ExplosionIntervalMaxPrecision;
+                        break;
+                    case InvasionTargetingStrategy.MaximumDamage:
+                        ExplosionInterval = settings.ExplosionIntervalMaxDamage;
+                        break;
+                    default:
+                    case InvasionTargetingStrategy.Balanced:
+                        ExplosionInterval = settings.ExplosionIntervalBalanced;
+                        break;
+                }
+            }
+
+            string soundEffect = null;
+            var playbackDuration = TimeSpan.Zero;
+
+            switch (SelectedAction)
+            {
+                case InvasionAction.AttackOrbitalDefenses:
+                    playbackDuration = settings.AttackOrbitalDefensesReplayDuration;
+                    soundEffect= "AttackOrbitalDefenses";
+                    break;
+                case InvasionAction.BombardPlanet:
+                    playbackDuration = settings.BombardmentReplayDuration;
+                    soundEffect= "Bombardment_SM";
+                    break;
+                case InvasionAction.UnloadAllOrdinance:
+                    playbackDuration = settings.UnloadAllOrdinanceReplayDuration;
+                    soundEffect = "Bombardment_LG";
+                    break;
+                case InvasionAction.LandTroops:
+                    playbackDuration = settings.LandTroopsReplayDuration;
+                    soundEffect = "CombatLaser";
+                    break;
+            }
+
+            if (soundEffect != null)
+                _soundPlayer.Play("GroundCombat", soundEffect);
+
+            if (ClientSettings.Current.EnableCombatScreen == false)
+            {
+                //GameLog.Print("SystemAssault - Quick Running");
+                playbackDuration = TimeSpan.FromSeconds(1);
+                GameLog.Client.General.DebugFormat("SystemAssault - Quick Running, PlaybackDuration={0}, ClientSettings.Current.EnableCombatScreen={1}", playbackDuration.ToString(), ClientSettings.Current.EnableCombatScreen);
+                soundEffect = "CombatAll";
+            }
+
+            Observable
+                .Timer(playbackDuration, Scheduler.ThreadPool)
+                .ObserveOnDispatcher()
+                .Subscribe(
+                    _ =>
+                    {
+                        ExplosionInterval = null;
+                        ProcessUpdateCallback(false, update);
+                    });
+        }
+
+        public void ProcessUpdate([NotNull] InvasionArena update)
+        {
+            if (update == null)
+                throw new ArgumentNullException("update");
+
+            var newInvasion = (_currentUpdate == null || _currentUpdate.InvasionID != update.InvasionID);
+            if (newInvasion ||
+                SelectedAction == InvasionAction.StandDown)
+            {
+                ProcessUpdateCallback(newInvasion, update);
+                return;
+            }
+
+            PlaybackResults(update);
+        }
+
+        private void ProcessUpdateCallback(bool newInvasion, InvasionArena update)
+        {
+            _currentUpdate = update;
+
+            var colony = update.Colony;
+
+            RoundNumber = update.RoundNumber;
+            OnInvasionStatusChanged();
+
+            if (newInvasion)
+            {
+                StarSystem = GameContext.Current.Universe.Map[colony.Location].System;
+                GameLog.Client.General.DebugFormat("New Invasion on {0} at {1}", GameContext.Current.Universe.Map[colony.Location].System, GameContext.Current.Universe.Map[colony.Location].Location);
+
+                PrimaryPlanet = StarSystem.Planets
+                    .OrderByDescending(p => p.GetGrowthRate(colony.Inhabitants))
+                    .ThenByDescending(p => p.GetMaxPopulation(colony.Inhabitants))
+                    .FirstOrDefault();
+
+                Invader = update.Invader;
+                Defender = StarSystem.Owner;
+
+                _invadingUnits.Clear();
+                _troopTransports.ForEach(o => o.IsSelectedChanged -= OnTroopTransportIsSelectedChanged);
+                _troopTransports.Clear();
+                _destroyedInvadingUnits.Clear();
+                _defendingUnits.Clear();
+                _destroyedDefendingUnits.Clear();
+
+                _invadingUnits.AddRange(update.InvadingUnits.Select(o => new AssaultUnitViewModel(o)));
+                _defendingUnits.AddRange(update.DefendingUnits.Select(o => new AssaultUnitViewModel(o)));
+
+                _invadingUnits
+                    .Where(o => o.Category == AssaultUnitCategory.TroopTransport && !o.IsDestroyed)
+                    .ForEach(
+                        o =>
+                        {
+                            o.IsSelected = true;
+                            o.IsSelectedChanged += OnTroopTransportIsSelectedChanged;
+                            _troopTransports.Add(o);
+                        });
+
+                UpdateSelectedTransportsCombatStrength();
+
+                _defenderPopulation.SetValues(update.Population);
+                _colonyShieldStrength.SetValues(update.ColonyShieldStrength);
+                _defenderCombatStrength.Maximum = update.DefenderCombatStrength;
+                _defenderCombatStrength.Reset(update.DefenderCombatStrength);
+                // GameLog.Print("New Invasion (Round 1) on {0} at {1}, _defenderPopulation={2}, Population={3}", GameContext.Current.Universe.Map[colony.Location].System, GameContext.Current.Universe.Map[colony.Location], 
+                //                                            _defenderPopulation, GameContext.Current.Universe.Map[colony.Location].System.Colony.Population);
+            }
+            else
+            {
+                //works   GameLog.Print("Proceeding Invasion on {0} at {1}, Round={2}", GameContext.Current.Universe.Map[colony.Location].System, GameContext.Current.Universe.Map[colony.Location], RoundNumber);
+                foreach (var invadingUnit in update.InvadingUnits)
+                {
+                    var model = _invadingUnits.FirstOrDefault(o => Equals(o.Unit, invadingUnit));
+                    if (model == null)
+                        continue;
+
+                    model.UpdateUnit(invadingUnit);
+
+                    if (invadingUnit.IsDestroyed)
+                    {
+                        _invadingUnits.Remove(model);
+                        _troopTransports.Remove(model);
+                        model.IsSelectedChanged -= OnTroopTransportIsSelectedChanged;
+                        _destroyedInvadingUnits.Add(model);
+                    }
+                }
+
+                foreach (var defendingUnit in update.DefendingUnits)
+                {
+                    var model = _defendingUnits.FirstOrDefault(o => Equals(o.Unit, defendingUnit));
+                    if (model == null)
+                        continue;
+
+                    model.UpdateUnit(defendingUnit);
+
+                    if (defendingUnit.IsDestroyed)
+                    {
+                        _defendingUnits.Remove(model);
+                        _destroyedDefendingUnits.Add(model);
+                    }
+                }
+            }
+
+            _defenderPopulation.SetValues(update.Population);
+            _colonyShieldStrength.SetValues(update.ColonyShieldStrength);
+            _defenderCombatStrength.CurrentValue = update.DefenderCombatStrength;
+
+
+
+            GameLog.Client.General.DebugFormat("Proceeding Invasion on {0} at {1} (Round {4}), LastPopulation={2}, _currentDefenderPopulation={3}", GameContext.Current.Universe.Map[colony.Location].System, GameContext.Current.Universe.Map[colony.Location].Location,
+                                            GameContext.Current.Universe.Map[colony.Location].System.Colony.Population, _defenderPopulation, RoundNumber);
+
+            if (update.IsFinished)
+                SelectedAction = null;
+
+            if (newInvasion)
+            {
+                _stateManager.TryChange(SystemAssaultScreenState.AwaitingPlayerOrders);
+            }
+            else
+            {
+                var nextState = update.IsFinished ? SystemAssaultScreenState.Finished : SystemAssaultScreenState.AwaitingPlayerOrders;
+                _stateManager.TryChange(nextState);
+            }
+        }
+    }
+
+    public enum AssaultUnitCategory
+    {
+        CombatantShip,
+        TroopTransport,
+        OrbitalBattery,
+        ProductionFacility,
+        MilitaryStructure,
+        CivilianStructure
+    }
+
+    public class AssaultUnitViewModel : INotifyPropertyChanged
+    {
+        private readonly AssaultUnitCategory _category;
+        private readonly int _troopCount;
+        private InvasionUnit _unit;
+
+        public AssaultUnitViewModel([NotNull] InvasionUnit unit)
+        {
+            if (unit == null)
+                throw new ArgumentNullException("unit");
+
+            UpdateUnit(unit);
+
+            _category = ResolveCategory(_unit);
+
+            if (_category == AssaultUnitCategory.TroopTransport)
+                _troopCount = CombatHelper.ComputeGroundCombatStrength(unit.Source.Owner, unit.Source.Location, ((Ship)(unit.Source)).ShipDesign.WorkCapacity);
+        }
+
+        public InvasionUnit Unit
+        {
+            get { return _unit; }
+        }
+
+        public int TroopCount
+        {
+            get { return _troopCount; }
+        }
+
+        private static AssaultUnitCategory ResolveCategory(InvasionUnit unit)
+        {
+            if (unit is InvasionFacility)
+                return AssaultUnitCategory.ProductionFacility;
+
+            var structure = unit as InvasionStructure;
+            if (structure != null)
+            {
+                var design = (BuildingDesign)structure.Design;
+                var militaryBonuses = design.GetBonuses(
+                    BonusType.PercentGroundCombat,
+                    BonusType.PercentGroundDefense,
+                    BonusType.PlanetaryShielding,
+                    BonusType.PlanetaryShielding,
+                    BonusType.PercentPlanetaryShielding);
+
+                if (militaryBonuses.Any())
+                    return AssaultUnitCategory.MilitaryStructure;
+
+                return AssaultUnitCategory.CivilianStructure;
+            }
+
+            if (unit.Source is OrbitalBattery)
+                return AssaultUnitCategory.OrbitalBattery;
+
+            var orbital = unit as InvasionOrbital;
+            if (orbital != null &&
+                ((Ship)orbital.Source).ShipType == ShipType.Transport)
+            {
+                return AssaultUnitCategory.TroopTransport;
+            }
+
+            return AssaultUnitCategory.CombatantShip;
+        }
+
+        public void UpdateUnit([NotNull] InvasionUnit unit)
+        {
+            if (unit == null)
+                throw new ArgumentNullException("unit");
+
+            _unit = unit;
+
+            OnHasShieldsChanged();
+            OnShieldStrengthChanged();
+            OnHitPointsChanged();
+            OnIsDestroyedChanged();
+        }
+
+        #region ShieldStrength Property
+
+        [field: NonSerialized]
+        public event EventHandler ShieldStrengthChanged;
+
+        public Meter ShieldStrength
+        {
+            get
+            {
+                var orbital = _unit as InvasionOrbital;
+                if (orbital == null)
+                    return null;
+                return orbital.ShieldStrength;
+            }
+        }
+
+        protected virtual void OnShieldStrengthChanged()
+        {
+            ShieldStrengthChanged.Raise(this);
+            OnPropertyChanged("ShieldStrength");
+        }
+
+        #endregion
+
+        #region HitPoints Property
+
+        [field: NonSerialized]
+        public event EventHandler HitPointsChanged;
+
+        public Meter HitPoints
+        {
+            get
+            {
+                var orbital = _unit as InvasionOrbital;
+                if (orbital == null)
+                    return _unit.Health;
+                return orbital.HullStrength;
+            }
+        }
+
+        protected virtual void OnHitPointsChanged()
+        {
+            HitPointsChanged.Raise(this);
+            OnPropertyChanged("HitPoints");
+        }
+
+        #endregion
+
+        #region HasShields Property
+
+        [field: NonSerialized]
+        public event EventHandler HasShieldsChanged;
+
+        public bool HasShields
+        {
+            get
+            {
+                var orbital = _unit as InvasionOrbital;
+
+                return orbital != null &&
+                       orbital.Source.ShieldStrength.Maximum > 0;
+            }
+        }
+
+        protected virtual void OnHasShieldsChanged()
+        {
+            HasShieldsChanged.Raise(this);
+            OnPropertyChanged("HasShields");
+        }
+
+        #endregion
+
+        #region IsDestroyed Property
+
+        [field: NonSerialized]
+        public event EventHandler IsDestroyedChanged;
+
+        public bool IsDestroyed
+        {
+            get { return _unit.IsDestroyed; }
+        }
+
+        protected virtual void OnIsDestroyedChanged()
+        {
+            IsDestroyedChanged.Raise(this);
+            OnPropertyChanged("IsDestroyed");
+        }
+
+        #endregion
+
+        #region IsSelected Property
+
+        [field: NonSerialized]
+        public event EventHandler IsSelectedChanged;
+
+        private bool _isSelected;
+
+        public bool IsSelected
+        {
+            get { return _isSelected; }
+            set
+            {
+                if (Equals(value, _isSelected))
+                    return;
+
+                _isSelected = value;
+
+                OnIsSelectedChanged();
+            }
+        }
+
+        protected virtual void OnIsSelectedChanged()
+        {
+            IsSelectedChanged.Raise(this);
+            OnPropertyChanged("IsSelected");
+        }
+
+        #endregion
+
+        #region Design Property
+
+        public TechObjectDesign Design
+        {
+            get { return _unit.Design; }
+        }
+
+        #endregion
+
+        #region Name Property
+
+        public string Name
+        {
+            get { return _unit.Name; }
+        }
+
+        #endregion
+
+        #region Category Property
+
+        public AssaultUnitCategory Category
+        {
+            get { return _category; }
+        }
+
+        #endregion
+
+        #region Implementation of INotifyPropertyChanged
+
+        [NonSerialized] private PropertyChangedEventHandler _propertyChanged;
+
+        event PropertyChangedEventHandler INotifyPropertyChanged.PropertyChanged
+        {
+            add
+            {
+                while (true)
+                {
+                    var oldHandler = _propertyChanged;
+                    var newHandler = (PropertyChangedEventHandler)Delegate.Combine(oldHandler, value);
+
+                    if (Interlocked.CompareExchange(ref _propertyChanged, newHandler, oldHandler) == oldHandler)
+                        return;
+                }
+            }
+            remove
+            {
+                while (true)
+                {
+                    var oldHandler = _propertyChanged;
+                    var newHandler = (PropertyChangedEventHandler)Delegate.Remove(oldHandler, value);
+
+                    if (Interlocked.CompareExchange(ref _propertyChanged, newHandler, oldHandler) == oldHandler)
+                        return;
+                }
+            }
+        }
+
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            _propertyChanged.Raise(this, propertyName);
+        }
+
+        #endregion
+    }
+
+    public class AssaultScreenSettings : SupportInitializeBase, INotifyPropertyChanged
+    {
+        private TimeSpan _explosionIntervalMaxPrecision = TimeSpan.FromSeconds(0.75);
+        private TimeSpan _explosionIntervalBalanced = TimeSpan.FromSeconds(0.5);
+        private TimeSpan _explosionIntervalMaxDamage = TimeSpan.FromSeconds(0.25);
+        private TimeSpan _explosionIntervalUnloadAllOrdinance = TimeSpan.FromSeconds(0.05);
+        private TimeSpan _attackOrbitalDefensesReplayDuration = TimeSpan.FromSeconds(11);
+        private TimeSpan _bombardmentReplayDuration = TimeSpan.FromSeconds(8);
+        private TimeSpan _unloadAllOrdinanceReplayDuration = TimeSpan.FromSeconds(11);
+        private TimeSpan _landTroopsReplayDuration = TimeSpan.FromSeconds(16);
+
+        public TimeSpan ExplosionIntervalMaxPrecision
+        {
+            get { return _explosionIntervalMaxPrecision; }
+            set
+            {
+                VerifyInitializing();
+                _explosionIntervalMaxPrecision = value;
+                OnPropertyChanged("ExplosionIntervalMaxPrecision");
+            }
+        }
+
+        public TimeSpan ExplosionIntervalBalanced
+        {
+            get { return _explosionIntervalBalanced; }
+            set
+            {
+                VerifyInitializing();
+                _explosionIntervalBalanced = value;
+                OnPropertyChanged("ExplosionIntervalBalanced");
+            }
+        }
+
+        public TimeSpan ExplosionIntervalMaxDamage
+        {
+            get { return _explosionIntervalMaxDamage; }
+            set
+            {
+                VerifyInitializing();
+                _explosionIntervalMaxDamage = value;
+                OnPropertyChanged("ExplosionIntervalMaxDamage");
+            }
+        }
+
+        public TimeSpan ExplosionIntervalUnloadAllOrdinance
+        {
+            get { return _explosionIntervalUnloadAllOrdinance; }
+            set
+            {
+                VerifyInitializing();
+                _explosionIntervalUnloadAllOrdinance = value;
+                OnPropertyChanged("ExplosionIntervalUnloadAllOrdinance");
+            }
+        }
+
+        public TimeSpan AttackOrbitalDefensesReplayDuration
+        {
+            get { return _attackOrbitalDefensesReplayDuration; }
+            set
+            {
+                VerifyInitializing();
+                _attackOrbitalDefensesReplayDuration = value;
+                OnPropertyChanged("AttackOrbitalDefensesReplayDuration");
+            }
+        }
+
+        public TimeSpan BombardmentReplayDuration
+        {
+            get { return _bombardmentReplayDuration; }
+            set
+            {
+                VerifyInitializing();
+                _bombardmentReplayDuration = value;
+                OnPropertyChanged("BombardmentReplayDuration");
+            }
+        }
+
+        public TimeSpan UnloadAllOrdinanceReplayDuration
+        {
+            get { return _unloadAllOrdinanceReplayDuration; }
+            set
+            {
+                VerifyInitializing();
+                _unloadAllOrdinanceReplayDuration = value;
+                OnPropertyChanged("UnloadAllOrdinanceReplayDuration");
+            }
+        }
+
+        public TimeSpan LandTroopsReplayDuration
+        {
+            get { return _landTroopsReplayDuration; }
+            set
+            {
+                VerifyInitializing();
+                _landTroopsReplayDuration = value;
+                OnPropertyChanged("LandTroopsReplayDuration");
+            }
+        }
+
+        #region Shared Instance
+
+        private static AssaultScreenSettings _instance;
+
+        public static AssaultScreenSettings Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new AssaultScreenSettings();
+                    _instance.Refresh();
+                }
+                return _instance;
+            }
+        }
+
+        #endregion
+
+        #region I/O Operations
+
+        private const string DataFileUri = "vfs:///Resources/Data/AssaultScreenSettings.xaml";
+
+        public void Refresh()
+        {
+            try
+            {
+                IVirtualFileInfo dataFile;
+
+                if (!ResourceManager.VfsService.TryGetFileInfo(new Uri(DataFileUri), out dataFile) ||
+                    !dataFile.Exists)
+                {
+                    // nobody knows structure or content of this file
+                    //GameLog.Client.GameData.WarnFormat(
+                    //    "Could not locate data file \"{0}\".  Using default values instead.",
+                    //    DataFileUri);
+
+                    return;
+                }
+
+                using (var stream = dataFile.OpenRead())
+                {
+                    XamlHelper.LoadInto(this, stream);
+                }
+            }
+            catch (Exception e)
+            {
+                GameLog.Client.GameData.Error(
+                    string.Format(
+                        "An error occurred while loading data file \"{0}\".  " +
+                        "Check the error log for exception details.",
+                        DataFileUri),
+                    e);
+            }
+        }
+
+        #endregion
+
+        #region Implementation of INotifyPropertyChanged
+
+        [NonSerialized] private PropertyChangedEventHandler _propertyChanged;
+
+        event PropertyChangedEventHandler INotifyPropertyChanged.PropertyChanged
+        {
+            add
+            {
+                while (true)
+                {
+                    var oldHandler = _propertyChanged;
+                    var newHandler = (PropertyChangedEventHandler)Delegate.Combine(oldHandler, value);
+
+                    if (Interlocked.CompareExchange(ref _propertyChanged, newHandler, oldHandler) == oldHandler)
+                        return;
+                }
+            }
+            remove
+            {
+                while (true)
+                {
+                    var oldHandler = _propertyChanged;
+                    var newHandler = (PropertyChangedEventHandler)Delegate.Remove(oldHandler, value);
+
+                    if (Interlocked.CompareExchange(ref _propertyChanged, newHandler, oldHandler) == oldHandler)
+                        return;
+                }
+            }
+        }
+
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            _propertyChanged.Raise(this, propertyName);
+        }
+
+        #endregion
+    }
+}

--- a/SupremacyCore/Combat/AutomatedCombatEngine.cs
+++ b/SupremacyCore/Combat/AutomatedCombatEngine.cs
@@ -1,649 +1,1306 @@
 // AutomatedCombatEngine.cs
+
 //
+
 // Copyright (c) 2007 Mike Strobel
+
 //
+
 // This source code is subject to the terms of the Microsoft Reciprocal License (Ms-RL).
+
 // For details, see <http://www.opensource.org/licenses/ms-rl.html>.
+
 //
+
 // All other rights reserved.
 
+
+
 using Supremacy.Collections;
+
 using Supremacy.Diplomacy;
+
 using Supremacy.Entities;
+
 using Supremacy.Orbitals;
+
 using Supremacy.Utility;
+
 using System;
+
 using System.Collections.Generic;
+
 using System.Linq;
 
 
+
+
+
 namespace Supremacy.Combat
+
 {
+
     public sealed class AutomatedCombatEngine : CombatEngine
+
     {
+
         private double cycleReduction = 1d;
+
         private double newCycleReduction = 1d;
+
         private double excessShipsStartingAt;
+
         private double shipRatio = 1;
+
         private bool friendlyOwner = true;
-        bool HeroShip = false;
+
+        // bool HeroShip = false; No longer needed
+
         private object firstOwner;
+
         private int wearkerSide =0; // 0= no bigger ships counts, 1= First Friendly side bigger, 2 Oppostion side bigger
+
         private List<Tuple<CombatUnit, CombatWeapon[]>> _friendlyCombatShips;
+
         private List<Tuple<CombatUnit, CombatWeapon[]>> _oppositionCombatShips;
 
+
+
         public List<Tuple<CombatUnit, CombatWeapon[]>> FriendlyCombatShips
+
         {
+
             get
+
             {
+
                 return this._friendlyCombatShips;
+
             }
+
             set
+
             {
+
                 this._friendlyCombatShips = value;
+
             }
+
         }
+
         public List<Tuple<CombatUnit, CombatWeapon[]>> OppositionCombatShips
+
         {
+
             get
+
             {
+
                 return this._oppositionCombatShips;
+
             }
+
             set
+
             {
+
                 this._oppositionCombatShips = value;
+
             }
+
         }
+
+
+
+
 
 
 
         //private readonly SendCombatUpdateCallback _updateCallback;
+
         public AutomatedCombatEngine(
+
             List<CombatAssets> assets,
+
             SendCombatUpdateCallback updateCallback,
+
             NotifyCombatEndedCallback combatEndedCallback)
+
             : base(assets, updateCallback, combatEndedCallback)
+
         {
 
+
+
         }
+
+
 
         private void CastType(object firstOwner)
+
         {
+
             Civilization actualType = (Civilization)firstOwner;
+
         }
 
+
+
         protected override void ResolveCombatRoundCore()
+
         {
+
+            // Setting variables to standard (initilization)
+            shipRatio = 1;
+            excessShipsStartingAt = 0; 
+            wearkerSide = 0;
+            cycleReduction = 1;
+            newCycleReduction = 1;
+
 
             int maxScanStrengthOpposition = 0;
 
+
+
             // Scouts, Frigate and cloaked ships have a special chance of retreating BEFORE round 3
+
             if (_roundNumber < 3)
+
             {
+                //  Once a ship has retreated, its important that it does not do it again..
                 var easyRetreatShips = _combatShips
+
                     .Where(s => s.Item1.IsCloaked == true || (s.Item1.Source.OrbitalDesign.ShipType == "Frigate") || (s.Item1.Source.OrbitalDesign.ShipType == "Scout"))
+
+                    .Where(s => !s.Item1.IsDestroyed) //  Destroyed ships cannot retreat
                     .Where(s => GetOrder(s.Item1.Source) == CombatOrder.Retreat)
+
                     .ToList();
 
+
+
                 foreach (var ship in easyRetreatShips)
+
                 {
+
                     if (!RandomHelper.Chance(10) && (ship.Item1 != null))
+
                     {
+
                         var ownerAssets = GetAssets(ship.Item1.Owner);
-                        ownerAssets.EscapedShips.Add(ship.Item1);
-                        ownerAssets.CombatShips.Remove(ship.Item1);
-                        ownerAssets.NonCombatShips.Remove(ship.Item1);
-                        _combatShips.Remove(ship);
+
+                        if (!ownerAssets.EscapedShips.Contains(ship.Item1)) // escaped ships cannot escape again
+                        {
+                            ownerAssets.EscapedShips.Add(ship.Item1);
+
+                            ownerAssets.CombatShips.Remove(ship.Item1);
+
+                            ownerAssets.NonCombatShips.Remove(ship.Item1);
+
+                            _combatShips.Remove(ship);
+                        }
                     }
+
                 }
+
                 //Decloak any cloaked ships  
+
                 foreach (var combatShip in _combatShips)
+
                 {
+
                     if (combatShip.Item1.IsCloaked)
+
                     {
+
                         combatShip.Item1.Decloak();
+
                         GameLog.Core.Combat.DebugFormat("Ship  {0} {1} ({2}) cloak status {3})",
+
                             combatShip.Item1.Source.ObjectID, combatShip.Item1.Name, combatShip.Item1.Source.Design, combatShip.Item1.IsCloaked);
+
                     }
+
                 }
+
             }
+
             _combatShipsTemp = new List<Tuple<CombatUnit, CombatWeapon[]>>();
+
             _combatShipsTemp.Clear();
 
+
+
             OppositionCombatShips = new List<Tuple<CombatUnit, CombatWeapon[]>>();
+
             OppositionCombatShips.Clear();
 
+
+
             FriendlyCombatShips = new List<Tuple<CombatUnit, CombatWeapon[]>>();
+
             FriendlyCombatShips.Clear();
+
+
 
             var firstFriendlyUnit = _combatShips.FirstOrDefault();
 
+
+
             for (int i = 0; i < _combatShips.Count; i++)
+
             {
+
                 GameLog.Core.Combat.DebugFormat("unsorted combat ships {3} = {0} {1} ({2})",
+
                     _combatShips[i].Item1.Source.ObjectID, _combatShips[i].Item1.Source.Name, _combatShips[i].Item1.Source.Design, i);
+
             }
+
             foreach (var combatent in _combatShips)
+
             {
+
                 if (CombatHelper.WillEngage(combatent.Item1.Owner, firstFriendlyUnit.Item1.Owner))
+
                 {
+
                     OppositionCombatShips.Add(combatent);
+
                     OppositionCombatShips.Randomize();
-                }
-                else
-                {
-                    FriendlyCombatShips.Add(combatent);
-                    FriendlyCombatShips.Randomize();
-                }
-            }
-            if (OppositionCombatShips.Count == 0 || FriendlyCombatShips.Count == 0)
-            {
-                shipRatio = 1;
-                excessShipsStartingAt = 0;
-                wearkerSide = 0;
-            }
-            else
-            {
-                if (FriendlyCombatShips.Count - OppositionCombatShips.Count > 0)
-                {
-                    excessShipsStartingAt = OppositionCombatShips.Count * 2;
-                    shipRatio = FriendlyCombatShips.Count() / OppositionCombatShips.Count();
-                    wearkerSide = 1;
+
                 }
 
                 else
+
                 {
-                    excessShipsStartingAt = FriendlyCombatShips.Count * 2;
-                    shipRatio = OppositionCombatShips.Count() / FriendlyCombatShips.Count();
-                    wearkerSide = 2;
+
+                    FriendlyCombatShips.Add(combatent);
+
+                    FriendlyCombatShips.Randomize();
+
                 }
+
             }
-            if (FriendlyCombatShips.Count() == OppositionCombatShips.Count())
+
+
+            // Prevent division by 0, if one side has been wiped out / or retreated.
+            if (OppositionCombatShips.Count == 0 || FriendlyCombatShips.Count == 0)
+
+            {
+
+                shipRatio = 1; 
+
+                excessShipsStartingAt = 0; 
+
                 wearkerSide = 0;
+
+            }
+
+            else
+
+            {
+
+                if (FriendlyCombatShips.Count - OppositionCombatShips.Count > 0)
+
+                {
+
+                    excessShipsStartingAt = OppositionCombatShips.Count * 2;
+
+                    shipRatio = FriendlyCombatShips.Count() / OppositionCombatShips.Count();
+
+                    wearkerSide = 1;
+
+                }
+
+
+
+                else
+
+                {
+
+                    excessShipsStartingAt = FriendlyCombatShips.Count * 2;
+
+                    shipRatio = OppositionCombatShips.Count() / FriendlyCombatShips.Count();
+
+                    wearkerSide = 2;
+
+                }
+
+            }
+
+            if (FriendlyCombatShips.Count() == OppositionCombatShips.Count())
+
+                wearkerSide = 0;
+
+            if (shipRatio > 1.2)
+            {
+                newCycleReduction = 0.5;
+            }
+
 
             if (shipRatio > 1.5)
+
             {
+
                 newCycleReduction = 0.25;
+
             }
+
             if (shipRatio > 2)
+
             {
+
                 newCycleReduction = 0.15;
+
             }
+
             if (shipRatio > 3)
+
             {
+
                 newCycleReduction = 0.08;
+
             }
+
             if (shipRatio > 10)
+
             {
+
                 newCycleReduction = 0.05;
+
             }
-            for (int i = 0; i < _combatShips.Count; i++)
+            if(FriendlyCombatShips.Count() < 4 || OppositionCombatShips.Count() < 4) // small fleets attack each other at full power
             {
+                newCycleReduction = 1;
+            }
+            
+            for (int i = 0; i < _combatShips.Count; i++) // sorting combat Ships to have one ship of each side alternating
+
+            {
+
                 if (i <= FriendlyCombatShips.Count - 1)
-                    _combatShipsTemp.Add(FriendlyCombatShips[i]);// First Ship in _combatShipsTemp is Friendly (initialization)
+
+                    _combatShipsTemp.Add(FriendlyCombatShips[i]);// First Ship in _ is Friendly (initialization)
+
+
 
                 if (i <= OppositionCombatShips.Count - 1)
+
                     _combatShipsTemp.Add(OppositionCombatShips[i]); // Second Ship in _combatShipsTemp is opposition (initialization)
+
             }
+
+
+
+            _combatShips.Clear(); //  after ships where sorted into Temp, delete 
+            // the original Array. After that populate empty array with sorted temp array
 
             for (int i = 0; i < _combatShipsTemp.Count; i++)
             {
+                _combatShips.Add(_combatShipsTemp[i]);
+            }
+            _combatShipsTemp.Clear(); // Temp cleared for next runthrough
+
+
+
+
+            // Stop using Temp, only use it to sort and then get rid of it
+         
+
+            for (int i = 0; i < _combatShips.Count; i++) // 
+
+            {
+
                 GameLog.Core.Combat.DebugFormat("sorting Temp Ships {3} = {0} {1} ({2})",
-                    _combatShipsTemp[i].Item1.Source.ObjectID, _combatShipsTemp[i].Item1.Source.Name, _combatShipsTemp[i].Item1.Source.Design, i);
+                    
+                    _combatShips[i].Item1.Source.ObjectID, _combatShips[i].Item1.Source.Name, _combatShips[i].Item1.Source.Design, i);
+
             }
 
-            for (int i = 0; i < _combatShipsTemp.Count; i++)
+
+
+            for (int i = 0; i < _combatShips.Count; i++) 
+
             {
+
                 //GameLog.Core.Combat.DebugFormat("sorting Temp Ships {3} = {0} {1} ({2})",
+
                 //     _combatShipsTemp[i].Item1.Source.ObjectID, _combatShipsTemp[i].Item1.Source.Name, _combatShipsTemp[i].Item1.Source.Design, i);
 
-                var ownerAssets = GetAssets(_combatShipsTemp[i].Item1.Owner);
-                var oppositionShips = _combatShipsTemp.Where(cs => CombatHelper.WillEngage(_combatShipsTemp[i].Item1.Owner, cs.Item1.Owner));
-                var friendlyShips = _combatShipsTemp.Where(cs => !CombatHelper.WillEngage(_combatShipsTemp[i].Item1.Owner, cs.Item1.Owner));
 
-                if (i > excessShipsStartingAt)
+                
+                var ownerAssets = GetAssets(_combatShips[i].Item1.Owner);
+                
+
+                var oppositionShips = _combatShips.Where(cs => CombatHelper.WillEngage(_combatShips[i].Item1.Owner, cs.Item1.Owner));
+
+                var friendlyShips = _combatShips.Where(cs => !CombatHelper.WillEngage(_combatShips[i].Item1.Owner, cs.Item1.Owner));
+
+
+
+                if (i + 1 > excessShipsStartingAt && excessShipsStartingAt != 0) // added: if ships equal = 0 = excessShips, then no cycle reduction
+                {
                     cycleReduction = newCycleReduction;
+                } // +1 because a 2nd ship can have full firepower, but not the 3rd exceeding the other side
 
-                List<string> ownEmpires = _combatShipsTemp.Where(s =>
-                    (s.Item1.Owner == _combatShipsTemp[i].Item1.Owner))
+                
+                List<string> ownEmpires = _combatShips.Where(s =>
+
+                    (s.Item1.Owner == _combatShips[i].Item1.Owner))
+
                     .Select(s => s.Item1.Owner.Key)
+
                     .Distinct()
+
                     .ToList();
 
-                List<string> friendlyEmpires = _combatShipsTemp.Where(s =>
-                    (s.Item1.Owner != _combatShipsTemp[i].Item1.Owner) &&
-                    CombatHelper.WillFightAlongside(s.Item1.Owner, _combatShipsTemp[i].Item1.Owner))
+
+                
+                List<string> friendlyEmpires = _combatShips.Where(s =>
+
+                    (s.Item1.Owner != _combatShips[i].Item1.Owner) &&
+
+                    CombatHelper.WillFightAlongside(s.Item1.Owner, _combatShips[i].Item1.Owner))
+
                     .Select(s => s.Item1.Owner.Key)
+
                     .Distinct()
+
                     .ToList();
 
-                List<string> hostileEmpires = _combatShipsTemp.Where(s =>
-                    (s.Item1.Owner != _combatShipsTemp[i].Item1.Owner) &&
-                    CombatHelper.WillEngage(s.Item1.Owner, _combatShipsTemp[i].Item1.Owner))
+
+                
+                List<string> hostileEmpires = _combatShips.Where(s =>
+
+                    (s.Item1.Owner != _combatShips[i].Item1.Owner) &&
+
+                    CombatHelper.WillEngage(s.Item1.Owner, _combatShips[i].Item1.Owner))
+
                     .Select(s => s.Item1.Owner.Key)
+
                     .Distinct()
+
                     .ToList();
 
-                firstOwner = _combatShipsTemp[0].Item1.Owner;
-                if (CombatHelper.WillEngage(_combatShipsTemp[i].Item1.Owner, _combatShipsTemp[0].Item1.Owner) && _combatShipsTemp[0].Item1.Owner != _combatShipsTemp[i].Item1.Owner)
+
+                
+                firstOwner = _combatShips[0].Item1.Owner;
+
+                if (CombatHelper.WillEngage(_combatShips[i].Item1.Owner, _combatShips[0].Item1.Owner) && _combatShips[0].Item1.Owner != _combatShips[i].Item1.Owner)
+
                 {
+
                     friendlyOwner = false;
+
                 }
+
                 else
+
                 {
+
                     friendlyOwner = true;
+
                 }
+
+
 
                 int friendlyWeaponPower = ownEmpires.Sum(e => _empireStrengths[e]) + friendlyEmpires.Sum(e => _empireStrengths[e]);
+
                 int hostileWeaponPower = hostileEmpires.Sum(e => _empireStrengths[e]);
+
                 int weaponRatio = friendlyWeaponPower * 10 / (hostileWeaponPower + 1);
 
+
+
                 //Figure out if any of the opposition ships have sensors powerful enough to penetrate our camo. If so, will be decamo.
+
                 if (oppositionShips.Count() > 0)
 
+
+
                 {
+
                     maxScanStrengthOpposition = oppositionShips.Max(s => s.Item1.Source.OrbitalDesign.ScanStrength);
 
-                    if (_combatShipsTemp[i].Item1.IsCamouflaged && _combatShipsTemp[i].Item1.CamouflagedStrength < maxScanStrengthOpposition)
+
+                    
+                    if (_combatShips[i].Item1.IsCamouflaged && _combatShips[i].Item1.CamouflagedStrength < maxScanStrengthOpposition)
+
                     {
-                        _combatShipsTemp[i].Item1.Decamouflage();
+
+                        _combatShips[i].Item1.Decamouflage();
+
                         GameLog.Core.Combat.DebugFormat("{0} has camou strength {1} vs maxScan {2}",
-                            _combatShipsTemp[i].Item1.Name, _combatShipsTemp[i].Item1.CamouflagedStrength, maxScanStrengthOpposition);
+
+                            _combatShips[i].Item1.Name, _combatShips[i].Item1.CamouflagedStrength, maxScanStrengthOpposition);
+
                     }
+
                 }
+
+
 
                 //TODO: Move this to DiplomacyHelper
+
                 List<string> allEmpires = new List<string>();
+
                 allEmpires.AddRange(ownEmpires);
+
                 allEmpires.AddRange(friendlyEmpires);
+
                 allEmpires.AddRange(hostileEmpires);
+
                 foreach (var firstEmpire in allEmpires.Distinct().ToList())
+
                 {
+
                     foreach (var secondEmpire in allEmpires.Distinct().ToList())
+
                     {
+
                         if (!DiplomacyHelper.IsContactMade(Game.GameContext.Current.Civilizations[firstEmpire], Game.GameContext.Current.Civilizations[secondEmpire]))
+
                         {
-                            DiplomacyHelper.EnsureContact(Game.GameContext.Current.Civilizations[firstEmpire], Game.GameContext.Current.Civilizations[secondEmpire], _combatShipsTemp[0].Item1.Source.Location);
+
+                            DiplomacyHelper.EnsureContact(Game.GameContext.Current.Civilizations[firstEmpire], Game.GameContext.Current.Civilizations[secondEmpire], _combatShips[0].Item1.Source.Location);
+
                         }
+
                     }
+
                 }
 
+
+
                 bool oppositionIsRushing = oppositionShips.Any(os => os.Item1.Source.IsCombatant && (GetOrder(os.Item1.Source) == CombatOrder.Rush));
+
                 bool oppositionIsInFormation = oppositionShips.Any(os => os.Item1.Source.IsCombatant && (GetOrder(os.Item1.Source) == CombatOrder.Formation));
+
                 bool oppositionIsHailing = oppositionShips.Any(os => os.Item1.Source.IsCombatant && (GetOrder(os.Item1.Source) == CombatOrder.Hail));
+
                 bool oppositionIsRetreating = oppositionShips.Any(os => os.Item1.Source.IsCombatant && (GetOrder(os.Item1.Source) == CombatOrder.Retreat));
+
                 bool oppositionIsRaidTransports = oppositionShips.Any(os => os.Item1.Source.IsCombatant && (GetOrder(os.Item1.Source) == CombatOrder.Transports));
+
                 bool oppositionIsEngage = oppositionShips.Any(os => os.Item1.Source.IsCombatant && (GetOrder(os.Item1.Source) == CombatOrder.Engage));
 
-                var order = GetOrder(_combatShipsTemp[i].Item1.Source);
+
+                
+                var order = GetOrder(_combatShips[i].Item1.Source);
+
                 switch (order)
+
                 {
 
+
+
                     case CombatOrder.Engage:
+
                     case CombatOrder.Rush:
+
                     case CombatOrder.Transports:
+
                     case CombatOrder.Formation:
 
-                        var attackingShip = _combatShipsTemp[i].Item1;
+
+                        
+                        var attackingShip = _combatShips[i].Item1;
+
                         var target = ChooseTarget(attackingShip);
 
 
+
+
+
                         if (target == null)
+
                         {
+
                             GameLog.Core.Combat.DebugFormat("No target for {0} {1} ({2})", attackingShip.Source.ObjectID, attackingShip.Name, attackingShip.Source.Design);
+
                         }
+
                         if (target != null)
+
                         {
+
                             GameLog.Core.Combat.DebugFormat("Target for {0} {1} ({2}) is {3} {4} ({5})", attackingShip.Source.ObjectID, attackingShip.Name, attackingShip.Source.Design, target.Source.ObjectID, target.Name, target.Source.Design);
 
+
+
                             // If we rushed a formation we could take damage
+
                             int chanceRushingFormation = RandomHelper.Random(100);
+
                             if (oppositionIsInFormation && (order == CombatOrder.Rush || order == CombatOrder.Transports) && (chanceRushingFormation >= (int)((BaseChanceToRushFormation * 100))))
+
                             {
+
                                 attackingShip.TakeDamage(attackingShip.Source.OrbitalDesign.HullStrength / 4);  // 25 % down out of Hullstrength of TechObjectDatabase.xml
 
+
+
                                 GameLog.Core.Combat.DebugFormat("{0} {1} rushed or raid transports in formation and took {2} damage to hull ({3} hull left)",
+
                                     attackingShip.Source.ObjectID, attackingShip.Source.Name, attackingShip.Source.OrbitalDesign.HullStrength / 4, attackingShip.Source.HullStrength);
+
                             }
+
                             if (oppositionIsEngage && (order == CombatOrder.Formation || order == CombatOrder.Rush) && (chanceRushingFormation >= (int)((BaseChanceToRushFormation * 100))))
+
                             {
+
                                 attackingShip.TakeDamage(attackingShip.Source.OrbitalDesign.HullStrength / 5);  // 20 % down out of Hullstrength of TechObjectDatabase.xml
+
+
 
                                 GameLog.Core.Combat.DebugFormat("{0} {1} in Formation or Rushing while Engaged and took {2} damage to hull ({3} hull left)",
+
                                     attackingShip.Source.ObjectID, attackingShip.Source.Name, attackingShip.Source.OrbitalDesign.HullStrength / 4, attackingShip.Source.HullStrength);
+
                             }
+
                             if (oppositionIsRushing && (order == CombatOrder.Transports) && (chanceRushingFormation >= (int)((BaseChanceToRushFormation * 100))))
+
                             {
+
                                 attackingShip.TakeDamage(attackingShip.Source.OrbitalDesign.HullStrength / 5);  // 20 % down out of Hullstrength of TechObjectDatabase.xml
 
+
+
                                 GameLog.Core.Combat.DebugFormat("{0} {1} Raiding Transports and got Rushed took {2} damage to hull ({3} hull left)",
+
                                     attackingShip.Source.ObjectID, attackingShip.Source.Name, attackingShip.Source.OrbitalDesign.HullStrength / 4, attackingShip.Source.HullStrength);
+
                             }
+
                             if (oppositionIsRaidTransports && (order == CombatOrder.Engage) && (chanceRushingFormation >= (int)((BaseChanceToRushFormation * 100))))
+
                             {
+
                                 attackingShip.TakeDamage(attackingShip.Source.OrbitalDesign.HullStrength / 6);  // 17 % down out of Hullstrength of TechObjectDatabase.xml
 
+
+
                                 GameLog.Core.Combat.DebugFormat("{0} {1} Engag order got Raided and took {2} damage to hull ({3} hull left)",
+
                                     attackingShip.Source.ObjectID, attackingShip.Source.Name, attackingShip.Source.OrbitalDesign.HullStrength / 4, attackingShip.Source.HullStrength);
+
                             }
+
+
 
                             bool assimilationSuccessful = false;
+
                             //If the attacker is Borg, try and assimilate before you try destroying it
+
                             if (attackingShip.Owner.Name == "Borg" && target.Owner.Name != "Borg")
+
                             {
+
                                 GameLog.Core.Combat.DebugFormat("{0} {1} attempting assimilation on {2} {3}", attackingShip.Name, attackingShip.Source.ObjectID, target.Name, target.Source.ObjectID);
+
                                 int chanceToAssimilate = RandomHelper.Random(100);
+
                                 assimilationSuccessful = chanceToAssimilate <= (int)(BaseChanceToAssimilate * 100);
+
                             }
+
+
 
                             //Perform the assimilation, but only on ships
+
                             if (assimilationSuccessful && target.Source is Ship)
+
                             {
+
                                 GameLog.Core.Combat.DebugFormat("{0} {1} successfully assimilated {2} {3}", attackingShip.Name, attackingShip.Source.ObjectID, target.Name, target.Source.ObjectID);
 
+
+
                                 CombatAssets oppositionAssets = GetAssets(target.Owner);
+
                                 if (!ownerAssets.AssimilatedShips.Contains(target))
+
                                 {
+
                                     ownerAssets.AssimilatedShips.Add(target);
+
                                     target.IsAssimilated = true;
-                                }
-                                if (target.Source.IsCombatant)
-                                {
-                                    oppositionAssets.CombatShips.Remove(target);
-                                }
-                                else
-                                {
-                                    oppositionAssets.NonCombatShips.Remove(target);
+
                                 }
 
+                                if (target.Source.IsCombatant)
+
+                                {
+
+                                    oppositionAssets.CombatShips.Remove(target);
+
+                                }
+
+                                else
+
+                                {
+
+                                    oppositionAssets.NonCombatShips.Remove(target);
+
+                                }
+
+
+
                             }
+
                             else // if not assmilated attack, perform attack fire weapons
+
                             {
+
                                 //GameLog.Core.Combat.DebugFormat("{0} {1} ({2}) attacking {3} {4} ({5})", attackingShip.Source.ObjectID, attackingShip.Name, attackingShip.Source.Design, target.Source.ObjectID, target.Name, target.Source.Design);
 
-                                var weapons = _combatShipsTemp[i].Item2.Where(w => w.CanFire);
+
+                                
+                                var weapons = _combatShips[i].Item2.Where(w => w.CanFire);
+
                                 int amountOfWeapons = weapons.Count();
+
                                 var partlyFiring = 0;
 
-                                foreach (var weapon in _combatShipsTemp[i].Item2.Where(w => w.CanFire))
+
+                                
+                                foreach (var weapon in _combatShips[i].Item2.Where(w => w.CanFire))
+
                                 {
-                                    if (!target.IsDestroyed)
+
+                                    if (!target.IsDestroyed)  //&& !target.) // Bug?: do not target retreated ships
+
                                     {
+
                                         // just not firing full fire power of one ship before the other ship is firing, but ..
+
                                         // but each 2nd Weapon e.g. first 5 Beams than 3 Torpedos
-                                        if ((partlyFiring += 1) * 2 < amountOfWeapons)
-                                        {
+
+                                     //    commend unknown/old stuff if ((partlyFiring += 1) * 2 < amountOfWeapons)
+
+                                       // {
+
                                             GameLog.Core.Combat.DebugFormat("{0} {1} ({2}) attacking {3} {4} ({5}), amountOfWeapons = {6}, partlyFiring Step {7}",
+
                                                 attackingShip.Source.ObjectID, attackingShip.Name, attackingShip.Source.Design, target.Source.ObjectID, target.Name, target.Source.Design,
+
                                                 amountOfWeapons, partlyFiring);
 
+
+
                                             PerformAttack(attackingShip, target, weapon);
+
                                             
-                                        }
+
+                                        //}
+
                                     }
+
                                 }
+
                                 // all weapons fired for current ship i
 
+
+
                             }
-                            // now we are outside the if else for combat orders including past assimilation borg not borg 
+
+
                         }
 
-                        foreach (var combatShip in _combatShipsTemp)
+
+                        
+                        foreach (var combatShip in _combatShips)
+
                         {
+
                             if (combatShip.Item1.IsDestroyed)
+
                             {
+
                                 ownerAssets.AssimilatedShips.Remove(target);
+
                             }
+
                         }
+
+
 
                         break;
+
+
 
                     case CombatOrder.Retreat:
-                        if (WasRetreateSuccessful(_combatShipsTemp[i].Item1, oppositionIsRushing, oppositionIsEngage, oppositionIsInFormation, oppositionIsHailing, oppositionIsRetreating, oppositionIsRaidTransports, weaponRatio))
+                        
+                        if (WasRetreateSuccessful(_combatShips[i].Item1, oppositionIsRushing, oppositionIsEngage, oppositionIsInFormation, oppositionIsHailing, oppositionIsRetreating, oppositionIsRaidTransports, weaponRatio))
+
                         {
 
-                            if (!ownerAssets.EscapedShips.Contains(_combatShipsTemp[i].Item1))
+
+                            // added destroyed ship cannot retreat
+                            if (!ownerAssets.EscapedShips.Contains(_combatShips[i].Item1) && !_combatShips[i].Item1.IsDestroyed)
+
                             {
-                                ownerAssets.EscapedShips.Add(_combatShipsTemp[i].Item1);
+                                
+                                ownerAssets.EscapedShips.Add(_combatShips[i].Item1);
+
                             }
-                            if (_combatShipsTemp[i].Item1.Source.IsCombatant)
+                            
+                            if (_combatShips[i].Item1.Source.IsCombatant)
+
                             {
-                                ownerAssets.CombatShips.Remove(_combatShipsTemp[i].Item1);
-                            }
-                            else
-                            {
-                                ownerAssets.NonCombatShips.Remove(_combatShipsTemp[i].Item1);
+                                
+                                ownerAssets.CombatShips.Remove(_combatShips[i].Item1);
+
                             }
 
-                            _combatShipsTemp.Remove(_combatShipsTemp[i]);
+                            else
+
+                            {
+                                
+                                ownerAssets.NonCombatShips.Remove(_combatShips[i].Item1);
+
+                            }
+
+
+                            
+                            _combatShips.Remove(_combatShips[i]);
+
                         }
+
+
 
                         // Chance of hull damage if you fail to retreat and are being rushed
+
                         else if (oppositionIsRushing && (weaponRatio > 1))
+
                         {
-                            _combatShipsTemp[i].Item1.TakeDamage(_combatShipsTemp[i].Item1.Source.OrbitalDesign.HullStrength / 2);  // 50 % down out of Hullstrength of TechObjectDatabase.xml
+                            
+                            _combatShips[i].Item1.TakeDamage(_combatShips[i].Item1.Source.OrbitalDesign.HullStrength / 2);  // 50 % down out of Hullstrength of TechObjectDatabase.xml
+
+
 
                             GameLog.Core.Combat.DebugFormat("{0} {1} failed to retreat whilst being rushed and took {2} damage to hull ({3} hull left)",
-                                _combatShipsTemp[i].Item1.Source.ObjectID, _combatShipsTemp[i].Item1.Source.Name, _combatShipsTemp[i].Item1.Source.OrbitalDesign.HullStrength / 2, _combatShipsTemp[i].Item1.Source.HullStrength);
+                                
+                                _combatShips[i].Item1.Source.ObjectID, _combatShips[i].Item1.Source.Name, _combatShips[i].Item1.Source.OrbitalDesign.HullStrength / 2, _combatShips[i].Item1.Source.HullStrength);
+
                         }
+
                         break;
 
-                    case CombatOrder.Hail:
-                        GameLog.Core.Combat.DebugFormat("{1} {0} ({2}) hailing...", _combatShipsTemp[i].Item1.Name, _combatShipsTemp[i].Item1.Source.ObjectID, _combatShipsTemp[i].Item1.Source.Design.Name);
+
+
+                    case CombatOrder.Hail: 
+
+                        GameLog.Core.Combat.DebugFormat("{1} {0} ({2}) hailing...", _combatShips[i].Item1.Name, _combatShips[i].Item1.Source.ObjectID, _combatShips[i].Item1.Source.Design.Name);
+
                         break;
 
-                    case CombatOrder.Standby:
-                        GameLog.Core.Combat.DebugFormat("{1} {0} ({2}) standing by...", _combatShipsTemp[i].Item1.Name, _combatShipsTemp[i].Item1.Source.ObjectID, _combatShipsTemp[i].Item1.Source.Design.Name);
+
+
+                    case CombatOrder.Standby: 
+
+                        GameLog.Core.Combat.DebugFormat("{1} {0} ({2}) standing by...", _combatShips[i].Item1.Name, _combatShips[i].Item1.Source.ObjectID, _combatShips[i].Item1.Source.Design.Name);
+
+                        break;
+
+
+
+                }
+              
+            }
+
+
+
+            //Make sure that the station has a go at the enemy too
+
+            if ((_combatStation != null) && !_combatStation.Item1.IsDestroyed)
+
+            {
+
+                var order = GetOrder(_combatStation.Item1.Source);
+
+
+
+                CombatUnit target = null;
+
+                switch (order)
+
+                {
+
+                    case CombatOrder.Engage:
+
+                    case CombatOrder.Rush:
+
+                    case CombatOrder.Transports:
+
+                    case CombatOrder.Formation:
+
+                        target = ChooseTarget(_combatStation.Item1);
+
                         break;
 
                 }
-                // now remove destroid ships while inside the _combatShipsTemp looping
-                if (_combatShipsTemp[i].Item1.IsDestroyed)
-                {
-                    GameLog.Core.Combat.DebugFormat("{0} {1} ({2}) was destroyed", _combatShipsTemp[i].Item1.Source.ObjectID, _combatShipsTemp[i].Item1.Name, _combatShipsTemp[i].Item1.Source.Design);
-                    CombatAssets targetAssets = GetAssets(_combatShipsTemp[i].Item1.Owner);
-                    if (_combatShipsTemp[i].Item1.Source is Ship)
-                    {
-                        //var ownerAssets = GetAssets(_combatShipsTemp[i].Item1.Owner);
-                        var oppositionAssets = GetAssets(_combatShipsTemp[i].Item1.Owner);
 
-                        if (!oppositionAssets.DestroyedShips.Contains(_combatShipsTemp[i].Item1))
+
+
+                if (target != null)
+
+                {
+
+                    foreach (CombatWeapon weapon in _combatStation.Item2.Where(w => w.CanFire))
+
+                    {
+
+                        PerformAttack(_combatStation.Item1, target, weapon);
+
+                    }
+
+                }
+
+            }
+
+
+            // remove desroyed ships. Now on this spot, so that they can fire, but get still removed later
+            foreach (var combatent in _combatShips) // now earch for destroyed ships
+            {
+                if (combatent.Item1.IsDestroyed)
+                {
+                    GameLog.Core.Combat.DebugFormat("Opposition {0} {1} ({2}) was destroyed", combatent.Item1.Source.ObjectID, combatent.Item1.Name, combatent.Item1.Source.Design);
+
+                    if (combatent.Item1.Source is Ship)
+                    {
+                        var Assets = GetAssets(combatent.Item1.Owner);
+                        if (!Assets.DestroyedShips.Contains(combatent.Item1))
                         {
-                            oppositionAssets.DestroyedShips.Add(_combatShipsTemp[i].Item1);
+                            Assets.DestroyedShips.Add(combatent.Item1);
                         }
-                        if (_combatShipsTemp[i].Item1.Source.IsCombatant)
+                        if (combatent.Item1.Source.IsCombatant)
                         {
-                            oppositionAssets.CombatShips.Remove(_combatShipsTemp[i].Item1);
+                            Assets.CombatShips.Remove(combatent.Item1);
                         }
                         else
                         {
-                            oppositionAssets.NonCombatShips.Remove(_combatShipsTemp[i].Item1);
+                            Assets.NonCombatShips.Remove(combatent.Item1);
                         }
-                        _combatShips.RemoveAll(cs => cs.Item1 == _combatShipsTemp[i].Item1);
+
                     }
+                    continue;
                 }
             }
 
-            //Make sure that the station has a go at the enemy too
-            if ((_combatStation != null) && !_combatStation.Item1.IsDestroyed)
+
+            //End the combat... at turn X = 5, by letting all sides reteat
+            if (_roundNumber == 5) // equals 4 engagements. Minors need an A.I. to find back to homeworld then...
             {
-                var order = GetOrder(_combatStation.Item1.Source);
+                _roundNumber += 1;
+                var allRetreatShips = _combatShips
+                    .Where(s => !s.Item1.IsDestroyed)
+                    .ToList();
 
-                CombatUnit target = null;
-                switch (order)
+                foreach (var ship in allRetreatShips)
                 {
-                    case CombatOrder.Engage:
-                    case CombatOrder.Rush:
-                    case CombatOrder.Transports:
-                    case CombatOrder.Formation:
-                        target = ChooseTarget(_combatStation.Item1);
-                        break;
-                }
-
-                if (target != null)
-                {
-                    foreach (CombatWeapon weapon in _combatStation.Item2.Where(w => w.CanFire))
+                    if (ship.Item1 != null)
                     {
-                        PerformAttack(_combatStation.Item1, target, weapon);
+                        var ownerAssets = GetAssets(ship.Item1.Owner);
+                        if (!ownerAssets.EscapedShips.Contains(ship.Item1))
+                        {
+                            ownerAssets.EscapedShips.Add(ship.Item1);
+                            ownerAssets.CombatShips.Remove(ship.Item1);
+                            ownerAssets.NonCombatShips.Remove(ship.Item1);
+                            _combatShips.Remove(ship);
+                        }
+
+
                     }
                 }
-            }
+            }// end to end combat
+
+
+            
         }
 
+
+
         /// <summary>
+
         /// Chooses a target for the given <see cref="CombatUnit"/>
+
         /// </summary>
+
         /// <param name="attacker"></param>
+
         /// <returns></returns>
+
         private CombatUnit ChooseTarget(CombatUnit attacker)
+
         {
+
             if (attacker == null)
+
             {
+
                 throw new ArgumentNullException();
+
             }
+
+
 
             var attackerOrder = GetOrder(attacker.Source);
+
             var attackerShipOwner = attacker.Owner;
 
+
+
             if ((attackerOrder == CombatOrder.Hail) || (attackerOrder == CombatOrder.LandTroops) || (attackerOrder == CombatOrder.Retreat) || (attackerOrder == CombatOrder.Standby))
+
             {
+
                 throw new ArgumentException("Cannot chose a target for a ship that does not have orders that require a target");
+
             }
 
-            List<Tuple<CombatUnit, CombatWeapon[]>> oppositionShips = _combatShipsTemp.Where(cs => CombatHelper.WillEngage(attacker.Owner, cs.Item1.Owner) && !cs.Item1.IsCloaked && !cs.Item1.IsDestroyed && attackerShipOwner != cs.Item1.Owner).ToList();
+
+            // needs to add, not retreated.
+            List<Tuple<CombatUnit, CombatWeapon[]>> oppositionShips = _combatShips.Where(cs => CombatHelper.WillEngage(attacker.Owner, cs.Item1.Owner) && !cs.Item1.IsCloaked && !cs.Item1.IsDestroyed && attackerShipOwner != cs.Item1.Owner).ToList();
+
             bool hasOppositionStation = (_combatStation != null) && !_combatStation.Item1.IsDestroyed && (_combatStation.Item1.Owner != attacker.Owner);
+
             while (true)
+
             {
+
                 switch (attackerOrder)
+
                 {
+
                     case CombatOrder.Engage:
+
                     case CombatOrder.Formation:
+
                         //Only ships to target                     
+
                         if (!hasOppositionStation && (oppositionShips.Count() > 0))
+
                         {
+
                             return oppositionShips.FirstOrDefault().Item1;
+
                         }
+
                         //Has both ships and station to target
+
                         if (hasOppositionStation && (oppositionShips.Count() > 0))
+
                         {
+
                             if (RandomHelper.Random(5) == 0)
+
                             {
+
                                 return _combatStation.Item1;
+
                             }
-                            return oppositionShips.FirstOrDefault().Item1;
+
+                            return oppositionShips.FirstOrDefault().Item1; // ´MAYBE needs change that target cannot be retreated ships...
+
                         }
+
                         //Only has a station to target
+
                         if (hasOppositionStation)
+
                         {
+
                             return _combatStation.Item1;
+
                         }
+
                         //Nothing to target
+
                         return null;
 
+
+
                     case CombatOrder.Rush:
+
                         //If there are any ships that are retreating, target them
-                        var oppositionRetreating = _combatShipsTemp.Where(cs => CombatHelper.WillEngage(attacker.Owner, cs.Item1.Owner) && (GetOrder(cs.Item1.Source) == CombatOrder.Retreat) && !cs.Item1.IsDestroyed);
+                       
+
+                        var oppositionRetreating = _combatShips.Where(cs => CombatHelper.WillEngage(attacker.Owner, cs.Item1.Owner) && (GetOrder(cs.Item1.Source) == CombatOrder.Retreat) && !cs.Item1.IsDestroyed);
+
                         if (oppositionRetreating.Count() > 0)
+
                         {
+
                             return oppositionRetreating.First().Item1;
+
                         }
+
                         attackerOrder = CombatOrder.Engage;
+
                         break;
+
+
 
                     case CombatOrder.Transports:
+
                         //If there are transports and they are not in formation, target them
-                        var oppositionTransports = _combatShipsTemp.Where(cs => CombatHelper.WillEngage(attacker.Owner, cs.Item1.Owner) && (cs.Item1.Source.OrbitalDesign.ShipType == "Transport") && !cs.Item1.IsDestroyed);
+
+                        var oppositionTransports = _combatShips.Where(cs => CombatHelper.WillEngage(attacker.Owner, cs.Item1.Owner) && (cs.Item1.Source.OrbitalDesign.ShipType == "Transport") && !cs.Item1.IsDestroyed);
+
                         bool oppositionIsInFormation = oppositionShips.Any(os => os.Item1.Source.IsCombatant && (GetOrder(os.Item1.Source) == CombatOrder.Formation));
+
                         if ((oppositionTransports.Count() > 0) && (!oppositionIsInFormation))
+
                         {
+
                             return oppositionTransports.First().Item1;
+
                         }
+
                         //If there any ships retreating, target them
-                        var oppositionRetreatingRaid = _combatShipsTemp.Where(cs => CombatHelper.WillEngage(attacker.Owner, cs.Item1.Owner) && (GetOrder(cs.Item1.Source) == CombatOrder.Retreat) && !cs.Item1.IsDestroyed);
+                        
+
+                        var oppositionRetreatingRaid = _combatShips.Where(cs => CombatHelper.WillEngage(attacker.Owner, cs.Item1.Owner) && (GetOrder(cs.Item1.Source) == CombatOrder.Retreat) && !cs.Item1.IsDestroyed);
+
                         if (oppositionRetreatingRaid.Count() > 0)
+
                         {
+
                             return oppositionRetreatingRaid.First().Item1;
+
                         }
+
                         attackerOrder = CombatOrder.Engage;
+
                         break;
+
                 }
+
             }
+
         }
+
         /// <summary>
+
         /// Deals damage to the target, and calculates whether the target has been destroyed
+
         /// </summary>
+
         /// <param name="source"></param>
+
         /// <param name="target"></param>
+
         /// <param name="weapon"></param>
+
         /// 
 
+
+
         private void PerformAttack(CombatUnit source, CombatUnit target, CombatWeapon weapon)
+
         {
+
             var sourceAccuracy = source.Source.GetAccuracyModifier(); // var? Or double?
-            if (sourceAccuracy > 1)  // if getting a 10 from the table
-                sourceAccuracy = sourceAccuracy / 10;
+
+            if (sourceAccuracy > 1 || sourceAccuracy < 0.1)  // if getting odd numbers, take normal one, until bug fixed
+
+                sourceAccuracy = 0.5;
+
+
 
             var targetDamageControl = target.Source.GetDamageControlModifier();
-            if (targetDamageControl > 1)  // if getting a 10 from the table
-                targetDamageControl = targetDamageControl / 10;
-           
-            // Federation has 7 Enterprises and 2 other Hero Ships
 
-            // 13 Romulan Hero Ships
+            if (targetDamageControl > 1 || targetDamageControl < 0.1)  // if getting damge control is odd, take standard until bug fixed
 
-            // 12 Klingon Hero Ships
+                targetDamageControl = 0.5;
 
-            // 5 Cardassians
 
-            // 1 Dominion
-
-            // 3 Borg Ships
-
-            // Bashir
-
-            if (source.Name.Contains("!"))
-                HeroShip = true; // If fireing ship is Hero Ship? 
-
-            if (HeroShip == true)
+            // if side ==2 is stronger, they get the bonus
+            if (wearkerSide == 1)
             {
-                sourceAccuracy = sourceAccuracy * 1.2; // add 20% accuracy
-                targetDamageControl = 1; // Best Damage control for HeroShips
-                HeroShip = false; // reset HeroShip to false
+
+                if (source.Owner != firstOwner || !friendlyOwner) //Plz DOUBLECHECK
+
+                {
+                    sourceAccuracy = 1.0 + (1 - newCycleReduction);
+                    if (sourceAccuracy > 1.5)
+                    {
+                        sourceAccuracy = 1.45;
+                    }
+                    cycleReduction = 1;
+                } // First (friend) owner is source owner or performAttack is on a friendlyOwner as source owner call from the _combatShipTemp cycle
+
+            }
+            else if (wearkerSide == 0)
+            {
+                // if wearkerSide == 0, then both are equal. Do no change
+                cycleReduction = 1;
+            }
+            else if (wearkerSide == 2) // Meaning the current ship is of the stronger side
+            {
+                cycleReduction = newCycleReduction;
             }
 
-            if (RandomHelper.Random(100) <= (100 * sourceAccuracy))  // not every weapons hits a target
-                if (wearkerSide == 1) // if weakeSide equals 1 then first(friendly) side is bigger
-                {
-                    if (source.Owner != firstOwner || !friendlyOwner) // if it is the smaller side improve accuracy
-                    {
-                        sourceAccuracy = 1.6 - (newCycleReduction *2);
-                    } 
-                }
-                {
-                    target.TakeDamage((int)(weapon.MaxDamage.CurrentValue * (1.5 - targetDamageControl) * sourceAccuracy * cycleReduction * 3));
 
-                    if (RandomHelper.Random(100) <= (100 * sourceAccuracy))  // not every weapons gets a hit
-                {
-                    target.TakeDamage((int)(weapon.MaxDamage.CurrentValue * targetDamageControl * sourceAccuracy * cycleReduction * 3));
 
+
+            // if firing ship OR targeted ship are heroShips, change values to be better.
+            if (source.Name.Contains("!"))
+            {
+                sourceAccuracy = 1.7; // change to 170% accuracy
+            }
+            
+            if (target.Name.Contains("!"))
+            {
+                targetDamageControl = 1;
+            }
+
+
+
+            if (RandomHelper.Random(100) <= (100 * sourceAccuracy))  // not every weapons does a hit
+            { 
+                            
+                   
+                // Fire Weapons, inflict damage
+                    target.TakeDamage((int)(weapon.MaxDamage.CurrentValue * (1.5 - targetDamageControl) * sourceAccuracy * cycleReduction * 4 + 50)); // minimal damage of 50 included
+
+                    
+               
                     GameLog.Core.Combat.DebugFormat("{0} {1} ({2}) took damage *3 of all {3} (cycleReduction = {4}, sourceAccuracy = {5}), targetDamageControl = {6}, targetShields = {7}, hull = {8}",
+
                         target.Source.ObjectID, target.Name, target.Source.Design,
+
                         (int)(weapon.MaxDamage.CurrentValue * targetDamageControl * sourceAccuracy * cycleReduction),
+
                         cycleReduction,
+
                         sourceAccuracy,
+
                         targetDamageControl,
+
                         target.ShieldStrength,
+
                         target.HullStrength
+
                         );
 
-
-                    //cycleReduction *= 0.98;
-                    //if (cycleReduction < 0.6)
-                    //    cycleReduction = 0.6;
-                }
-                weapon.Discharge();
+                
             }
 
+                weapon.Discharge();
+
         }
+
+
+
     }
+
 }
+
+
+
+

--- a/SupremacyCore/Combat/AutomatedCombatEngine.cs
+++ b/SupremacyCore/Combat/AutomatedCombatEngine.cs
@@ -611,13 +611,13 @@ namespace Supremacy.Combat
                 HeroShip = false; // reset HeroShip to false
             }
 
-            if (RandomHelper.Random(100) <= (100 * sourceAccuracy))  // not every weapons does a hit
-                if (wearkerSide == 1)
+            if (RandomHelper.Random(100) <= (100 * sourceAccuracy))  // not every weapons hits a target
+                if (wearkerSide == 1) // if weakeSide equals 1 then first(friendly) side is bigger
                 {
-                    if (source.Owner != firstOwner || !friendlyOwner)
+                    if (source.Owner != firstOwner || !friendlyOwner) // if it is the smaller side improve accuracy
                     {
                         sourceAccuracy = 1.6 - (newCycleReduction *2);
-                    } // First (friend) owner is source owner or performAttack is on a friendlyOwner as source owner call from the _combatShipTemp cycle
+                    } 
                 }
                 {
                     target.TakeDamage((int)(weapon.MaxDamage.CurrentValue * (1.5 - targetDamageControl) * sourceAccuracy * cycleReduction * 3));

--- a/SupremacyCore/Combat/AutomatedCombatEngine.cs
+++ b/SupremacyCore/Combat/AutomatedCombatEngine.cs
@@ -58,7 +58,7 @@ namespace Supremacy.Combat
 
         private object firstOwner;
 
-        private int wearkerSide =0; // 0= no bigger ships counts, 1= First Friendly side bigger, 2 Oppostion side bigger
+        private int wearkerSide =0; // 0= no bigger ships counts, 1= First Friendly side bigger, 2= Oppostion side bigger
 
         private List<Tuple<CombatUnit, CombatWeapon[]>> _friendlyCombatShips;
 
@@ -1219,34 +1219,56 @@ namespace Supremacy.Combat
                 targetDamageControl = 0.5;
 
 
-            // if side ==2 is stronger, they get the bonus
-            if (wearkerSide == 1)
+            // if side ==2 opposition is stronger, first frienldy side gets the bonus and side ==1 first friendly side has more ships, opposition side gets the bonus
+            switch (wearkerSide)
             {
-
-                if (source.Owner != firstOwner || !friendlyOwner) //Plz DOUBLECHECK
-
-                {
-                    sourceAccuracy = 1.0 + (1 - newCycleReduction);
-                    if (sourceAccuracy > 1.5)
+                //if (wearkerSide == 1) //first (Friendly) side has more ships
+                case 1:
                     {
-                        sourceAccuracy = 1.45;
+
+                        if (source.Owner != firstOwner || !friendlyOwner) //Plz DOUBLECHECK (If it is an opposition ship[ not first owner of firendly to first owner] improve on thier fire)
+
+                        {
+                            sourceAccuracy = 1.0 + (1 - newCycleReduction);
+                            if (sourceAccuracy > 1.5)
+                            {
+                                sourceAccuracy = 1.45;
+                            }
+                            cycleReduction = 1;
+                        }
+                        else
+                        {
+                            cycleReduction = newCycleReduction;
+                        }// First (friend) owner is source owner or performAttack is on a friendlyOwner as source owner call from the _combatShipTemp cycle
+                        break;
                     }
-                    cycleReduction = 1;
-                } // First (friend) owner is source owner or performAttack is on a friendlyOwner as source owner call from the _combatShipTemp cycle
+                //else if (wearkerSide == 0)
+                case 0:
+                    {
+                        // if wearkerSide == 0, then both are equal. Do no change
+                        cycleReduction = 1;
+                        break;
+                    }
+                //else if (wearkerSide == 2) 
+                case 2:// Opposition side has more ships so cycle
+                    {
+                        if (source.Owner == firstOwner || friendlyOwner) //Plz DOUBLECHECK (If it is samne owner as first, or friendly to first, improve on thier fire)
+                        {
+                            sourceAccuracy = 1.0 + (1 - newCycleReduction);
+                            if (sourceAccuracy > 1.5)
+                            {
+                                sourceAccuracy = 1.45;
+                            }
+                            cycleReduction = 1;
+                        } // First (friend) owner is source owner or performAttack is on a friendlyOwner as source owner call from the _combatShipTemp cycle
+                        else
+                        {
+                            cycleReduction = newCycleReduction;
+                        }
+                        break;
+                    }
 
             }
-            else if (wearkerSide == 0)
-            {
-                // if wearkerSide == 0, then both are equal. Do no change
-                cycleReduction = 1;
-            }
-            else if (wearkerSide == 2) // Meaning the current ship is of the stronger side
-            {
-                cycleReduction = newCycleReduction;
-            }
-
-
-
 
             // if firing ship OR targeted ship are heroShips, change values to be better.
             if (source.Name.Contains("!"))

--- a/SupremacyCore/Combat/CombatEngine.cs
+++ b/SupremacyCore/Combat/CombatEngine.cs
@@ -518,3 +518,4 @@ namespace Supremacy.Combat
         protected abstract void ResolveCombatRoundCore();
     }
 }
+


### PR DESCRIPTION
- A Clean up Code in AutomatedCombat
- Bug fix: Ships now either destroyed OR retreated.
- Strike Cruiser vs. Shields/Colony, refined (strike cruiser have special usage in system assault
- Strike Cruiser vs. Orbital (Re-alancing) List sorted, target = last. Test needed
- Normalize Accuracy Modifier due to get-Bug in combat
- Fix wrong Source Accuary and put it before Hero ships & cycleReduction (see B) Change heroship to "!" 
- Change heroship accuaracy to best = 1.7.
- Shield regeneration reduced after battle and based on %of in the ship XML. Base repair better.
- Ending Ship Combat after turn 5, to save (Multi-Player) time and add Strategy. ADD to en.txt
- Normalize Time for Invasion (Wait time from 11 to 2 seconds)
- Minifix. Multiplayer Invasion now 5 turns as in SP. (Was 3)
- Changed the extreme Events to start in turn 50 not in 20. Do not get hit so early in the game.