### PR TITLE
Tidy up of SitReps

### DIFF
--- a/SupremacyClientComponents/Dialogs/SitRepDetailDialog.xaml.cs
+++ b/SupremacyClientComponents/Dialogs/SitRepDetailDialog.xaml.cs
@@ -1,11 +1,9 @@
-﻿using System;
+﻿using Supremacy.Game;
+using Supremacy.Resources;
+using System;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
-
-using Supremacy.Annotations;
-using Supremacy.Game;
-using Supremacy.Resources;
 
 namespace Supremacy.Client.Dialogs
 {
@@ -17,7 +15,7 @@ namespace Supremacy.Client.Dialogs
         private readonly SitRepEntry _sitRepEntry;
         private readonly MediaPlayer _mediaPlayer;
 
-        private SitRepDetailDialog([NotNull] SitRepEntry sitRepEntry)
+        private SitRepDetailDialog(SitRepEntry sitRepEntry)
         {
             _sitRepEntry = sitRepEntry;
             if (sitRepEntry == null)
@@ -39,11 +37,10 @@ namespace Supremacy.Client.Dialogs
             Unloaded += (s, e) => _mediaPlayer.Stop();
         }
 
-        public static void Show([NotNull] SitRepEntry sitRepEntry)
+        public static void Show(SitRepEntry sitRepEntry)
         {
             if (sitRepEntry == null)
                 throw new ArgumentNullException("sitRepEntry");
-            //works, but only for DetailDialogs     GameLog.Client.GameData.DebugFormat("SitRepDetailDialog.xaml.cs: {0}", sitRepEntry.SummaryText);
             new SitRepDetailDialog(sitRepEntry).ShowDialog();
         }
 

--- a/SupremacyClientComponents/Dialogs/SitRepDialog.xaml.cs
+++ b/SupremacyClientComponents/Dialogs/SitRepDialog.xaml.cs
@@ -1,16 +1,15 @@
-﻿using System.Collections.Generic;
+﻿using Supremacy.Client.Commands;
+using Supremacy.Client.Controls;
+using Supremacy.Game;
+using Supremacy.Orbitals;
+using Supremacy.Universe;
+using Supremacy.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-
-using Supremacy.Client.Controls;
-using Supremacy.Game;
-using Supremacy.Utility;
-
-using System.Linq;
-using Supremacy.Universe;
-using Supremacy.Orbitals;
-using Supremacy.Client.Commands;
 
 namespace Supremacy.Client.Dialogs
 {
@@ -145,72 +144,37 @@ namespace Supremacy.Client.Dialogs
 
         private void OnSitRepEntryDoubleClick(object sender, RoutedEventArgs e)
         {
-            SitRepEntry selection = ItemsView.SelectedItem as SitRepEntry;
+            var selection = ItemsView.SelectedItem as SitRepEntry;
             if (selection != null)
             {
-                if (selection is ResearchCompleteSitRepEntry)
+                switch(selection.Action)
                 {
-                    Close();
-                    NavigationCommands.ActivateScreen.Execute(StandardGameScreens.ScienceScreen);
-                }
-                else if (selection is NewColonySitRepEntry)
-                {
-                    Close();
-                    GalaxyScreenCommands.SelectSector.Execute((selection as NewColonySitRepEntry).Colony.Sector);
-                    NavigationCommands.ActivateScreen.Execute(StandardGameScreens.ColonyScreen);
-                }
-                else if (selection is BuildQueueEmptySitRepEntry)
-                {
-                    Close();
-                    GalaxyScreenCommands.SelectSector.Execute((selection as BuildQueueEmptySitRepEntry).Colony.Sector);
-                    NavigationCommands.ActivateScreen.Execute(StandardGameScreens.ColonyScreen);
-                }
-                else if (selection is ItemBuiltSitRepEntry)
-                {
-                    ItemBuiltSitRepEntry entry = (ItemBuiltSitRepEntry)selection;
-                    Sector sector = GameContext.Current.Universe.Map[entry.Location];
-                    if ((entry.ItemType is ShipDesign) || (entry.ItemType is StationDesign))
-                    {
+                    case SitRepAction.ShowScienceScreen:
                         Close();
+                        NavigationCommands.ActivateScreen.Execute(StandardGameScreens.ScienceScreen);
+                        break;
+
+                    case SitRepAction.ViewColony:
+                        Close();
+                        GalaxyScreenCommands.SelectSector.Execute((selection.ActionTarget as Colony).Sector);
+                        NavigationCommands.ActivateScreen.Execute(StandardGameScreens.ColonyScreen);
+                        break;
+
+                    case SitRepAction.CenterOnSector:
+                        Close();
+                        var sector = selection.ActionTarget as Sector;
                         GalaxyScreenCommands.SelectSector.Execute(sector);
                         GalaxyScreenCommands.CenterOnSector.Execute(sector);
+                        break;
 
-                        // TODO: Could be nice to also automatically select the new ship/station??
-                    }
-                    else if ((sector.System != null) 
-                        && sector.System.HasColony
-                        && (sector.System.Colony.Owner == entry.Owner))
-                    {
+                    case SitRepAction.SelectTaskForce:
                         Close();
-                        GalaxyScreenCommands.SelectSector.Execute(sector);
-                        NavigationCommands.ActivateScreen.Execute(StandardGameScreens.ColonyScreen);
-                    }
-                }
-                else if (selection is StarvationSitRepEntry)
-                {
-                    StarvationSitRepEntry entry = (StarvationSitRepEntry)selection;
-                    if ((entry.System != null)
-                        && entry.System.HasColony
-                        && (entry.System.Colony.Owner == entry.Owner))
-                    {
-                        Close();
-                        GalaxyScreenCommands.SelectSector.Execute(entry.System.Colony.Sector);
-                        NavigationCommands.ActivateScreen.Execute(StandardGameScreens.ColonyScreen);
-                    }
-                }
-                else if (selection is FirstContactSitRepEntry)
-                {
-                    FirstContactSitRepEntry sitRep = selection as FirstContactSitRepEntry;
+                        var fleet = selection.ActionTarget as Fleet;
+                        GalaxyScreenCommands.SelectSector.Execute(fleet.Sector);
+                        GalaxyScreenCommands.CenterOnSector.Execute(fleet.Sector);
+                        GalaxyScreenCommands.SelectTaskForce.Execute(fleet);
+                        break;
 
-                    Close();
-                    GalaxyScreenCommands.SelectSector.Execute(sitRep.Sector);
-                    GalaxyScreenCommands.CenterOnSector.Execute(sitRep.Sector);
-                }
-                else if (selection is UnassignedTradeRoute)
-                {
-                    UnassignedTradeRoute sitRep = selection as UnassignedTradeRoute;
-                    Close();
-                    GalaxyScreenCommands.SelectSector.Execute((selection as UnassignedTradeRoute).TradeRoute.SourceColony.Location);
                 }
             }
         }

--- a/SupremacyClientComponents/Dialogs/SitRepDialogSettings.cs
+++ b/SupremacyClientComponents/Dialogs/SitRepDialogSettings.cs
@@ -1,7 +1,6 @@
+using Supremacy.Game;
 using System;
 using System.Windows;
-
-using Supremacy.Game;
 
 namespace Supremacy.Client.Dialogs
 {

--- a/SupremacyCore/Game/GameEngine.cs
+++ b/SupremacyCore/Game/GameEngine.cs
@@ -594,7 +594,7 @@ namespace Supremacy.Game
 
                     if ((shipsDamaged > 0) || (shipsDestroyed > 0))
                     {
-                        civManager.SitRepEntries.Add(new BlackHoleEncounterSitRepEntry(fleet.Owner, fleet.Sector.System, shipsDamaged, shipsDestroyed));
+                        civManager.SitRepEntries.Add(new BlackHoleEncounterSitRepEntry(fleet.Owner, fleet.Location, shipsDamaged, shipsDestroyed));
                     }
                 }
             }
@@ -984,7 +984,7 @@ namespace Supremacy.Game
                     GameLog.Core.Research.DebugFormat("{0} {1} gained {2} research points for {3} by studying the {4} in {5}",
                         scienceShip.ObjectID, scienceShip.Name, researchGained, owner, starType, scienceShip.Sector);
 
-                    GameContext.Current.CivilizationManagers[owner].SitRepEntries.Add(new ScienceShipResearchGainedSitRepEntry(owner.Civilization, scienceShip, researchGained, starType));
+                    GameContext.Current.CivilizationManagers[owner].SitRepEntries.Add(new ScienceShipResearchGainedSitRepEntry(owner.Civilization, scienceShip, researchGained));
                 }
                 catch (Exception e)
                 {

--- a/SupremacyCore/Scripting/Events/AsteroidImpactEvent.cs
+++ b/SupremacyCore/Scripting/Events/AsteroidImpactEvent.cs
@@ -168,19 +168,7 @@ namespace Supremacy.Scripting.Events
 
                     CivilizationManager civManager = GameContext.Current.CivilizationManagers[targetCiv.CivID];
                     if (civManager != null)
-                        civManager.SitRepEntries.Add(new AsteroidImpactSitRepEntry(civManager.Civilization, target.Name));
-
-                    // OLD
-                    //game.CivilizationManagers[targetCiv].SitRepEntries.Add(
-                    //    new ScriptedEventSitRepEntry(
-                    //        new ScriptedEventSitRepEntryData(
-                    //            targetCiv,
-                    //            "ASTEROID_IMPACT_HEADER_TEXT",
-                    //            "ASTEROID_IMPACT_SUMMARY_TEXT",
-                    //            "ASTEROID_IMPACT_DETAIL_TEXT",
-                    //            "vfs:///Resources/Images/ScriptedEvents/AsteroidImpact.png",
-                    //            "vfs:///Resources/SoundFX/ScriptedEvents/AsteroidImpact.wav",
-                    //            () => GameContext.Current.Universe.Get<Colony>(targetColonyId).Name)));
+                        civManager.SitRepEntries.Add(new AsteroidImpactSitRepEntry(civManager.Civilization, target));
 
                     GameContext.Current.Universe.UpdateSectors();
                     return;

--- a/SupremacyCore/Scripting/Events/Earthquake.cs
+++ b/SupremacyCore/Scripting/Events/Earthquake.cs
@@ -147,7 +147,7 @@ namespace Supremacy.Scripting.Events
                     CivilizationManager civManager = GameContext.Current.CivilizationManagers[targetCiv.CivID];
                     if (civManager != null)
                     {
-                        civManager.SitRepEntries.Add(new EarthquakeSitRepEntry(civManager.Civilization, target.Name));
+                        civManager.SitRepEntries.Add(new EarthquakeSitRepEntry(civManager.Civilization, target));
                     }
 
                     GameContext.Current.Universe.UpdateSectors();

--- a/SupremacyCore/Scripting/Events/GammaRayBurst.cs
+++ b/SupremacyCore/Scripting/Events/GammaRayBurst.cs
@@ -88,7 +88,7 @@ namespace Supremacy.Scripting.Events
                     CivilizationManager civManager = GameContext.Current.CivilizationManagers[targetCiv.CivID];
                     if (civManager != null)
                     {
-                        civManager.SitRepEntries.Add(new GammaRayBurstSitRepEntry(civManager.Civilization, target.Name));
+                        civManager.SitRepEntries.Add(new GammaRayBurstSitRepEntry(civManager.Civilization, target));
                     }
 
                     GameLog.Core.Events.DebugFormat("HomeSystemName is: {0}", target.Name);

--- a/SupremacyCore/Scripting/Events/MajorAsteroidImpact.cs
+++ b/SupremacyCore/Scripting/Events/MajorAsteroidImpact.cs
@@ -156,7 +156,7 @@ namespace Supremacy.Scripting.Events
                     CivilizationManager civManager = GameContext.Current.CivilizationManagers[targetCiv.CivID];
                     if (civManager != null)
                     {
-                        civManager.SitRepEntries.Add(new MajorAsteroidImpactSitRepEntry(civManager.Civilization, target.Name));
+                        civManager.SitRepEntries.Add(new MajorAsteroidImpactSitRepEntry(civManager.Civilization, target));
                     }
 
                     target.Population.UpdateAndReset();

--- a/SupremacyCore/Scripting/Events/PlagueEvent.cs
+++ b/SupremacyCore/Scripting/Events/PlagueEvent.cs
@@ -88,7 +88,7 @@ namespace Supremacy.Scripting.Events
                     CivilizationManager civManager = GameContext.Current.CivilizationManagers[targetCiv.CivID];
                     if (civManager != null)
                     {
-                        civManager.SitRepEntries.Add(new PlaqueSitRepEntry(civManager.Civilization, target.Name));
+                        civManager.SitRepEntries.Add(new PlaqueSitRepEntry(civManager.Civilization, target));
                     }
 
                     GameLog.Client.GameData.DebugFormat("HomeSystemName is: {0}", target.Name);

--- a/SupremacyCore/Scripting/Events/ReligiousHolidayEvent.cs
+++ b/SupremacyCore/Scripting/Events/ReligiousHolidayEvent.cs
@@ -109,7 +109,7 @@ namespace Supremacy.Scripting.Events
 
                     if (civManager != null)
                     {
-                        civManager.SitRepEntries.Add(new ReligiousHolidaySitRepEntry(civManager.Civilization, target.Name));
+                        civManager.SitRepEntries.Add(new ReligiousHolidaySitRepEntry(civManager.Civilization, target));
                     }
                 }
 

--- a/SupremacyCore/Scripting/Events/Supernovai.cs
+++ b/SupremacyCore/Scripting/Events/Supernovai.cs
@@ -85,7 +85,7 @@ namespace Supremacy.Scripting.Events
                     var civManager = GameContext.Current.CivilizationManagers[targetCiv.CivID];
                     if (civManager != null)
                     {
-                        civManager.SitRepEntries.Add(new SupernovaiSitRepEntry(civManager.Civilization, target.Name));
+                        civManager.SitRepEntries.Add(new SupernovaSitRepEntry(civManager.Civilization, target));
                     }
 
                     GameLog.Client.GameData.DebugFormat("HomeSystemName is: {0}", target.Name);

--- a/SupremacyCore/Scripting/Events/TerroristBombingOfShipProduction.cs
+++ b/SupremacyCore/Scripting/Events/TerroristBombingOfShipProduction.cs
@@ -119,7 +119,7 @@ namespace Supremacy.Scripting.Events
                         CivilizationManager civManager = GameContext.Current.CivilizationManagers[targetCiv.CivID];
                         if (civManager != null)
                         {
-                            civManager.SitRepEntries.Add(new TerroristBombingOfShipProductionSitRepEntry(civManager.Civilization, target.Name));
+                            civManager.SitRepEntries.Add(new TerroristBombingOfShipProductionSitRepEntry(civManager.Civilization, target));
                         }
 
                     }

--- a/SupremacyCore/Scripting/Events/TerroristsCaptured.cs
+++ b/SupremacyCore/Scripting/Events/TerroristsCaptured.cs
@@ -81,7 +81,7 @@ namespace Supremacy.Scripting.Events
                     var civManager = GameContext.Current.CivilizationManagers[targetCiv.CivID];
                     if (civManager != null)
                     {
-                        civManager.SitRepEntries.Add(new TerroristsCapturedSitRepEntry(civManager.Civilization, target.Name));
+                        civManager.SitRepEntries.Add(new TerroristsCapturedSitRepEntry(civManager.Civilization, target));
                     }
                 }
             }

--- a/SupremacyCore/Scripting/Events/TradeGuildStrikes.cs
+++ b/SupremacyCore/Scripting/Events/TradeGuildStrikes.cs
@@ -109,7 +109,7 @@ namespace Supremacy.Scripting.Events
                     CivilizationManager civManager = GameContext.Current.CivilizationManagers[targetCiv.CivID];
                     if (civManager != null)
                     {
-                        civManager.SitRepEntries.Add(new TradeGuildStrikesSitRepEntry(civManager.Civilization, target.Name));
+                        civManager.SitRepEntries.Add(new TradeGuildStrikesSitRepEntry(civManager.Civilization, target));
                     }
                 }
 

--- a/SupremacyCore/Scripting/Events/Tribbles.cs
+++ b/SupremacyCore/Scripting/Events/Tribbles.cs
@@ -103,7 +103,7 @@ namespace Supremacy.Scripting.Events
                     CivilizationManager civManager = GameContext.Current.CivilizationManagers[targetCiv.CivID];
                     if (civManager != null)
                     {
-                        civManager.SitRepEntries.Add(new TribblesSitRepEntry(civManager.Civilization, target.Name));
+                        civManager.SitRepEntries.Add(new TribblesSitRepEntry(civManager.Civilization, target));
                     }
 
                     GameContext.Current.Universe.UpdateSectors();


### PR DESCRIPTION
This pull request attempts to get rid of all extraneous crud from the SitReps, as well as adding a new code feature in - the ability to specify what to do when the SitRep is clicked on from within the SitRep instead of specifying what to do to for each different SitRep inside the Dialog (If you specify Action = CenterOnSector, ActionTarget *must* be a Sector, if you set Action = ViewColony then ActionTarget *must* be a colony, and if Action = SelectTaskForce, then ActionTarget *must* be a Fleet. The game *will* crash otherwise)